### PR TITLE
Update referencedata.facility_types.json

### DIFF
--- a/demo-data/referencedata.facility_types.json
+++ b/demo-data/referencedata.facility_types.json
@@ -2,15 +2,22 @@
   {
     "id": "00000000-0000-0000-0000-000000000001",
     "code": "FT001",
-    "name": "Facility Type Active",
+    "name": "HealthCenter",
     "active": "true",
     "displayOrder": 1
   },
   {
     "id": "00000000-0000-0000-0000-000000000002",
     "code": "FT002",
-    "name": "Facility Type Inactive",
-    "active": "false",
+    "name": "Distict Hospital",
+    "active": "true",
     "displayOrder": 2
-  }
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000003",
+    "code": "FT003",
+    "name": "Warehouse",
+    "active": "true",
+    "displayOrder": 3
+  },
 ]


### PR DESCRIPTION
I'm updating the demo data for beta. We should have a warehouse for the convert to order step.  I removed the inactive facility type because it wasn't clear to me why we needed to include a facility type which is inactive if we can activate and inactivate facilities themselves. 