### PR TITLE
Fix RG endpoints to allow associating facilities and schedules

### DIFF
--- a/src/main/java/org/openlmis/referencedata/domain/RequisitionGroup.java
+++ b/src/main/java/org/openlmis/referencedata/domain/RequisitionGroup.java
@@ -117,8 +117,10 @@ public class RequisitionGroup extends BaseEntity {
 
       for (RequisitionGroupProgramSchedule.Importer scheduleImporter :
           importer.getRequisitionGroupProgramSchedules()) {
-        requisitionGroupProgramSchedules.add(
-            RequisitionGroupProgramSchedule.newRequisitionGroupProgramSchedule(scheduleImporter));
+        RequisitionGroupProgramSchedule newRequisitionGroupProgramSchedule =
+            RequisitionGroupProgramSchedule.newRequisitionGroupProgramSchedule(scheduleImporter);
+        newRequisitionGroupProgramSchedule.setRequisitionGroup(newRequisitionGroup);
+        requisitionGroupProgramSchedules.add(newRequisitionGroupProgramSchedule);
       }
 
       newRequisitionGroup.requisitionGroupProgramSchedules = requisitionGroupProgramSchedules;

--- a/src/main/java/org/openlmis/referencedata/domain/RequisitionGroupProgramSchedule.java
+++ b/src/main/java/org/openlmis/referencedata/domain/RequisitionGroupProgramSchedule.java
@@ -73,7 +73,7 @@ public class RequisitionGroupProgramSchedule extends BaseEntity {
 
   private RequisitionGroupProgramSchedule(RequisitionGroup requisitionGroup, Program program,
                                           ProcessingSchedule schedule, boolean directDelivery) {
-    this.requisitionGroup = Objects.requireNonNull(requisitionGroup);
+    this.requisitionGroup = requisitionGroup;
     this.program = Objects.requireNonNull(program);
     this.processingSchedule = Objects.requireNonNull(schedule);
     this.directDelivery = directDelivery;

--- a/src/main/java/org/openlmis/referencedata/web/RequisitionGroupController.java
+++ b/src/main/java/org/openlmis/referencedata/web/RequisitionGroupController.java
@@ -16,7 +16,6 @@
 package org.openlmis.referencedata.web;
 
 import org.openlmis.referencedata.domain.RequisitionGroup;
-import org.openlmis.referencedata.dto.RequisitionGroupBaseDto;
 import org.openlmis.referencedata.dto.RequisitionGroupDto;
 import org.openlmis.referencedata.exception.NotFoundException;
 import org.openlmis.referencedata.exception.ValidationMessageException;
@@ -71,7 +70,7 @@ public class RequisitionGroupController extends BaseController {
   @ResponseStatus(HttpStatus.CREATED)
   @ResponseBody
   public RequisitionGroupDto createRequisitionGroup(
-      @RequestBody RequisitionGroupBaseDto requisitionGroupDto, BindingResult bindingResult) {
+      @RequestBody RequisitionGroupDto requisitionGroupDto, BindingResult bindingResult) {
     rightService.checkAdminRight(REQUISITION_GROUPS_MANAGE);
 
     LOGGER.debug("Creating new requisitionGroup");
@@ -139,7 +138,7 @@ public class RequisitionGroupController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public RequisitionGroupDto updateRequisitionGroup(
-      @RequestBody RequisitionGroupBaseDto requisitionGroupDto,
+      @RequestBody RequisitionGroupDto requisitionGroupDto,
       @PathVariable("id") UUID requisitionGroupId,
       BindingResult bindingResult) {
     rightService.checkAdminRight(REQUISITION_GROUPS_MANAGE);

--- a/src/test/java/org/openlmis/referencedata/domain/RequisitionGroupTest.java
+++ b/src/test/java/org/openlmis/referencedata/domain/RequisitionGroupTest.java
@@ -15,12 +15,15 @@
 
 package org.openlmis.referencedata.domain;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.openlmis.referencedata.dto.RequisitionGroupDto;
 
 import java.util.Collections;
 
@@ -36,6 +39,27 @@ public class RequisitionGroupTest {
     requisitionGroup.setRequisitionGroupProgramSchedules(Collections
         .singletonList(RequisitionGroupProgramSchedule.newRequisitionGroupProgramSchedule(
             requisitionGroup, program, mock(ProcessingSchedule.class), false)));
+  }
+
+  @Test
+  public void shouldAssociateRequisitionGroupAndScheduleProperlyFromImporter() {
+    RequisitionGroupDto dto = new RequisitionGroupDto();
+    dto.setCode("RG1");
+    dto.setName("RequisitionGroup1");
+    dto.setSupervisoryNode(mock(SupervisoryNode.class));
+    RequisitionGroupProgramSchedule schedule = RequisitionGroupProgramSchedule
+        .newRequisitionGroupProgramSchedule(null, program, mock(ProcessingSchedule.class), false);
+    dto.setRequisitionGroupProgramSchedules(Collections.singletonList(schedule));
+
+    RequisitionGroup actual = RequisitionGroup.newRequisitionGroup(dto);
+
+    assertNotNull(actual);
+    assertNotNull(actual.getRequisitionGroupProgramSchedules());
+    assertEquals(1, actual.getRequisitionGroupProgramSchedules().size());
+    assertEquals("RG1", actual.getRequisitionGroupProgramSchedules().get(0).getRequisitionGroup()
+        .getCode());
+    assertEquals("RequisitionGroup1", actual.getRequisitionGroupProgramSchedules().get(0)
+        .getRequisitionGroup().getName());
   }
 
   @Test


### PR DESCRIPTION
There were two problems with the POST/PUT endpoints for the
RequisitionGroup. The endpoint was not accepting the
memberFacilities and schedules fields at all since the DTO
did not contain them. Another problem was incorrect bi-directional
association between RG and schedule while creating the RG via
an importer from DTO.