### PR TITLE
OLMIS-2534: Fixed potential huge performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ New functionality added in a backwards-compatible manner:
 
 Bug fixes, security and performance improvements, also backwards-compatible:
 * [OLMIS-2871](https://openlmis.atlassian.net/browse/OLMIS-2871): The service now uses an Authorization header instead of an access_token request parameter when communicating with other services.
+* [OLMIS-2534](https://openlmis.atlassian.net/browse/OLMIS-2534): Fixed potential huge performance issue
 
 7.0.0 / 2017-06-23
 ==================


### PR DESCRIPTION
When the system starts, the javers log initializer retrieves all domain objects and creates history for those that don't have it (executes a query for each one).

It should (if possible) retrieve only some part of domain objects, create history for those entries and then retrieve another part.