### PR TITLE
OLMIS-7643: Create endpoint for data export

### DIFF
--- a/src/main/java/org/openlmis/referencedata/web/DataExportController.java
+++ b/src/main/java/org/openlmis/referencedata/web/DataExportController.java
@@ -1,0 +1,7 @@
+package org.openlmis.referencedata.web;
+
+public class DataExportController {
+
+
+
+}

--- a/src/main/java/org/openlmis/referencedata/web/DataExportController.java
+++ b/src/main/java/org/openlmis/referencedata/web/DataExportController.java
@@ -1,7 +1,32 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
 package org.openlmis.referencedata.web;
 
-import org.springframework.web.bind.annotation.RequestParam;
+import static org.openlmis.referencedata.web.DataExportController.RESOURCE_PATH;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+
+@Controller
+@RequestMapping(RESOURCE_PATH)
 public class DataExportController extends BaseController {
 
   public static final String RESOURCE_PATH = API_PATH + "/exportData";
@@ -11,6 +36,8 @@ public class DataExportController extends BaseController {
    *
    * @param data   The names of the files to be exported.
    */
+  @GetMapping
+  @ResponseStatus(HttpStatus.OK)
   public void exportData(@RequestParam(value = "data", required = true) String data) {
 
   }

--- a/src/main/java/org/openlmis/referencedata/web/DataExportController.java
+++ b/src/main/java/org/openlmis/referencedata/web/DataExportController.java
@@ -1,7 +1,18 @@
 package org.openlmis.referencedata.web;
 
-public class DataExportController {
+import org.springframework.web.bind.annotation.RequestParam;
 
+public class DataExportController extends BaseController {
 
+  public static final String RESOURCE_PATH = API_PATH + "/exportData";
+
+  /**
+   * Export data to a file of a given format.
+   *
+   * @param data   The names of the files to be exported.
+   */
+  public void exportData(@RequestParam(value = "data", required = true) String data) {
+
+  }
 
 }

--- a/src/main/java/org/openlmis/referencedata/web/DataExportController.java
+++ b/src/main/java/org/openlmis/referencedata/web/DataExportController.java
@@ -18,18 +18,19 @@ package org.openlmis.referencedata.web;
 import static org.openlmis.referencedata.web.DataExportController.RESOURCE_PATH;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 
 @Controller
 @RequestMapping(RESOURCE_PATH)
 public class DataExportController extends BaseController {
 
-  public static final String RESOURCE_PATH = API_PATH + "/exportData";
+  public static final String RESOURCE_PATH = "/exportData";
 
   /**
    * Export data to a file of a given format.
@@ -37,9 +38,9 @@ public class DataExportController extends BaseController {
    * @param data   The names of the files to be exported.
    */
   @GetMapping
-  @ResponseStatus(HttpStatus.OK)
-  public void exportData(@RequestParam(value = "data", required = true) String data) {
-
+  @ResponseBody
+  public ResponseEntity exportData(@RequestParam(value = "data", required = true) String data) {
+    return new ResponseEntity(HttpStatus.OK);
   }
 
 }

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -1722,7 +1722,21 @@ resourceTypes:
                           body:
                             application/json:
                               schema: localizedErrorResponse
-
+  /exportData:
+      displayName: Export data
+      get:
+          is: [ secured ]
+          description: Export data to a file of a given format.
+          queryParameters:
+              data:
+                  description: Data type
+                  type: string
+                  required: true
+                  repeat: false
+          responses:
+              "200":
+                  headers:
+                    Keep-Alive:
   /facilities:
       displayName: Facility
       get:

--- a/src/test/java/org/openlmis/referencedata/web/DataExportControllerTest.java
+++ b/src/test/java/org/openlmis/referencedata/web/DataExportControllerTest.java
@@ -1,6 +1,43 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
 package org.openlmis.referencedata.web;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+
+@ExtendWith(SpringExtension.class)
 class DataExportControllerTest {
 
+  private MockMvc mockMvc;
+
+  @BeforeAll
+  void init() {
+    mockMvc = MockMvcBuilders.standaloneSetup(DataExportController.class).build();
+  }
+
+  @Test
+  void exportDataTest() throws Exception {
+    mockMvc.perform(get("*/exportData")).andExpect(status().isOk());
+  }
 }

--- a/src/test/java/org/openlmis/referencedata/web/DataExportControllerTest.java
+++ b/src/test/java/org/openlmis/referencedata/web/DataExportControllerTest.java
@@ -1,0 +1,6 @@
+package org.openlmis.referencedata.web;
+
+import static org.junit.jupiter.api.Assertions.*;
+class DataExportControllerTest {
+
+}


### PR DESCRIPTION
The **DataExport** class with **exportData** method and annotations has been added.
In addition, a test class and one method for checking the http response status were added and the **api-definition** file was supplemented with a new endpoint.