### PR TITLE
OLMIS-7706-2: Changed validation method for data export query params

### DIFF
--- a/src/integration-test/java/org/openlmis/referencedata/web/DataExportControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/web/DataExportControllerIntegrationTest.java
@@ -116,15 +116,6 @@ public class DataExportControllerIntegrationTest extends BaseWebIntegrationTest 
   }
 
   @Test
-  public void shouldReturnBadRequestWhenUnsupportedParameterIsProvided() {
-    queryParamsMap.put("redundant-param-key", "redundant-param-value");
-
-    String response = getPathAsString();
-
-    assertEquals(response, DataExportMessageKeys.ERROR_INVALID_PARAMS);
-  }
-
-  @Test
   public void shouldReturnBadRequestWhenNoParametersProvided() {
     queryParamsMap.clear();
 
@@ -147,4 +138,3 @@ public class DataExportControllerIntegrationTest extends BaseWebIntegrationTest 
   }
 
 }
-

--- a/src/main/java/org/openlmis/referencedata/util/messagekeys/DataExportMessageKeys.java
+++ b/src/main/java/org/openlmis/referencedata/util/messagekeys/DataExportMessageKeys.java
@@ -21,7 +21,6 @@ public abstract class DataExportMessageKeys extends MessageKeys {
 
   private static final String ERROR_MISSING = join(ERROR, MISSING);
 
-  public static final String ERROR_INVALID_PARAMS = join(ERROR, INVALID_PARAMS);
   public static final String ERROR_MISSING_FORMAT_PARAMETER =
           join(ERROR_MISSING, FORMAT, PARAMETER);
 

--- a/src/main/java/org/openlmis/referencedata/web/DataExportController.java
+++ b/src/main/java/org/openlmis/referencedata/web/DataExportController.java
@@ -15,19 +15,11 @@
 
 package org.openlmis.referencedata.web;
 
-import static org.openlmis.referencedata.util.messagekeys.DataExportMessageKeys.ERROR_LACK_PARAMS;
-import static org.openlmis.referencedata.util.messagekeys.DataExportMessageKeys.ERROR_MISSING_DATA_PARAMETER;
-import static org.openlmis.referencedata.util.messagekeys.DataExportMessageKeys.ERROR_MISSING_FORMAT_PARAMETER;
 import static org.openlmis.referencedata.web.DataExportController.RESOURCE_PATH;
-import static org.openlmis.referencedata.web.DataExportParams.DATA;
-import static org.openlmis.referencedata.web.DataExportParams.FORMAT;
 
 import java.util.Map;
-
 import org.openlmis.referencedata.domain.RightName;
-import org.openlmis.referencedata.exception.ValidationMessageException;
 import org.openlmis.referencedata.service.DataExportService;
-import org.openlmis.referencedata.util.Message;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -47,7 +39,7 @@ public class DataExportController extends BaseController {
   private static final String RESPONSE_FILE_NAME = "OLMIS_configuration_data.zip";
 
   @Autowired
-  DataExportService dataExportService;
+  private DataExportService dataExportService;
 
 
   /**
@@ -62,22 +54,11 @@ public class DataExportController extends BaseController {
   @ResponseBody
   public ResponseEntity<byte[]> exportData(@RequestParam Map<String, String> requestParams) {
     rightService.checkAdminRight(RightName.DATA_EXPORT);
-    checkRequiredParams(requestParams);
 
     return ResponseEntity.ok()
             .contentType(MediaType.valueOf(ZIP_MEDIA_TYPE))
             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + RESPONSE_FILE_NAME)
             .body(dataExportService.exportData(new DataExportParams(requestParams)));
-  }
-
-  private void checkRequiredParams(Map<String, String> params) {
-    if (params.isEmpty()) {
-      throw new ValidationMessageException(new Message(ERROR_LACK_PARAMS));
-    } else if (!params.containsKey(DATA)) {
-      throw new ValidationMessageException(new Message(ERROR_MISSING_DATA_PARAMETER));
-    } else if (!params.containsKey(FORMAT)) {
-      throw new ValidationMessageException(new Message(ERROR_MISSING_FORMAT_PARAMETER));
-    }
   }
 
 }

--- a/src/main/java/org/openlmis/referencedata/web/DataExportParams.java
+++ b/src/main/java/org/openlmis/referencedata/web/DataExportParams.java
@@ -15,10 +15,10 @@
 
 package org.openlmis.referencedata.web;
 
-import static java.util.Arrays.asList;
-import static org.openlmis.referencedata.util.messagekeys.DataExportMessageKeys.ERROR_INVALID_PARAMS;
+import static org.openlmis.referencedata.util.messagekeys.DataExportMessageKeys.ERROR_LACK_PARAMS;
+import static org.openlmis.referencedata.util.messagekeys.DataExportMessageKeys.ERROR_MISSING_DATA_PARAMETER;
+import static org.openlmis.referencedata.util.messagekeys.DataExportMessageKeys.ERROR_MISSING_FORMAT_PARAMETER;
 
-import java.util.List;
 import java.util.Map;
 import lombok.ToString;
 import org.openlmis.referencedata.exception.ValidationMessageException;
@@ -31,8 +31,6 @@ public final class DataExportParams implements DataExportService.ExportParams {
   public static final String FORMAT = "format";
   public static final String DATA = "data";
 
-  private static final List<String> ALL_PARAMETERS = asList(FORMAT, DATA);
-
   private final Map<String, String> queryParams;
 
   public DataExportParams(Map<String, String> queryParams) {
@@ -42,27 +40,24 @@ public final class DataExportParams implements DataExportService.ExportParams {
 
   @Override
   public String getFormat() {
-    if (!queryParams.containsKey(FORMAT)) {
-      return null;
-    }
     return queryParams.get(FORMAT);
   }
 
   @Override
   public String getData() {
-    if (!queryParams.containsKey(DATA)) {
-      return null;
-    }
     return queryParams.get(DATA);
   }
 
   /**
-   * Checks if query params are valid. Throws an exception if any provided param is not on
-   * supported list.
+   * Checks if all params are present. Throws an exception if any parameter is missing.
    */
   private void validate() {
-    if (!ALL_PARAMETERS.containsAll(queryParams.keySet())) {
-      throw new ValidationMessageException(new Message(ERROR_INVALID_PARAMS));
+    if (queryParams.isEmpty()) {
+      throw new ValidationMessageException(new Message(ERROR_LACK_PARAMS));
+    } else if (!queryParams.containsKey(DATA)) {
+      throw new ValidationMessageException(new Message(ERROR_MISSING_DATA_PARAMETER));
+    } else if (!queryParams.containsKey(FORMAT)) {
+      throw new ValidationMessageException(new Message(ERROR_MISSING_FORMAT_PARAMETER));
     }
   }
 }

--- a/src/test/java/org/openlmis/referencedata/web/DataExportParamsTest.java
+++ b/src/test/java/org/openlmis/referencedata/web/DataExportParamsTest.java
@@ -17,59 +17,56 @@ package org.openlmis.referencedata.web;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.openlmis.referencedata.web.DataExportParams.DATA;
+import static org.openlmis.referencedata.web.DataExportParams.FORMAT;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Before;
 import org.junit.Test;
 import org.openlmis.referencedata.exception.ValidationMessageException;
 
 public class DataExportParamsTest {
 
-  private static final String VALUE = "test";
+  private static final String VALUE = "test-value";
+
+  private Map<String, String> queryMap;
+
+  @Before
+  public void setUp() {
+    queryMap = new HashMap<>();
+    queryMap.put(FORMAT, "init-format-value");
+    queryMap.put(DATA, "init-data-value");
+  }
 
   @Test
   public void getFormatShouldReturnValueForKeyFormat() {
-    Map<String, String> queryParamsMap = new HashMap<String, String>() {{
-        put("format", VALUE);
-      }
-    };
-    DataExportParams params = new DataExportParams(queryParamsMap);
+    queryMap.replace(FORMAT, VALUE);
+    DataExportParams params = new DataExportParams(queryMap);
 
     assertEquals(VALUE, params.getFormat());
   }
 
   @Test
-  public void getFormatShouldReturnNullIfMapDoesNotContainKeyFormat() {
-    DataExportParams params = new DataExportParams(new HashMap<>());
-
-    assertNull(VALUE, params.getFormat());
-  }
-
-  @Test
   public void getDataShouldReturnValueForKeyData() {
-    Map<String, String> queryParamsMap = new HashMap<String, String>() {{
-        put("data", VALUE);
-      }
-    };
-    DataExportParams params = new DataExportParams(queryParamsMap);
+    queryMap.replace(DATA, VALUE);
+    DataExportParams params = new DataExportParams(queryMap);
 
     assertEquals(VALUE, params.getData());
   }
 
-  @Test
-  public void getDataShouldReturnNullIfMapDoesNotContainKeyData() {
-    DataExportParams params = new DataExportParams(new HashMap<>());
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrownExceptionWhenFormatParameterIsMissing() {
+    queryMap.remove(FORMAT);
+    DataExportParams params = new DataExportParams(queryMap);
 
-    assertNull(VALUE, params.getData());
+    assertNull(params);
   }
 
   @Test(expected = ValidationMessageException.class)
-  public void shouldThrownExceptionWhenProvidedParamIsNotOnSupportedList() {
-    Map<String, String> queryParamsMap = new HashMap<String, String>() {{
-        put("some-param", VALUE);
-      }
-    };
-    DataExportParams params = new DataExportParams(queryParamsMap);
+  public void shouldThrownExceptionWhenDataParameterIsMissing() {
+    queryMap.remove(DATA);
+    DataExportParams params = new DataExportParams(queryMap);
 
     assertNull(params);
   }


### PR DESCRIPTION
Removed checking if all parameters belong to a specific list (format and data)