### PR TITLE
TZUP-445 Add a right for managing buq

### DIFF
--- a/src/main/resources/db/migration/20230725100417605__add-role-for-managing-buq.sql
+++ b/src/main/resources/db/migration/20230725100417605__add-role-for-managing-buq.sql
@@ -1,0 +1,1 @@
+INSERT INTO rights (id, description, name, type) VALUES ('6404e247-f57c-407d-a812-cac713e444b3', NULL, 'MANAGE_BUQ', 'GENERAL_ADMIN');


### PR DESCRIPTION
I digged into the frontend code and it feels like it will require its own frontend ticket to add a translation key for the new right, because for now it is displayed like this:
![Screenshot from 2023-07-25 16-13-32](https://github.com/OpenLMIS/openlmis-referencedata/assets/93163821/b9d10840-d9d9-4b10-a20b-e9dae7041050)

I will add a comment in the ticket.