### PR TITLE
CQI-14: Disable demo data loading for integration tests

### DIFF
--- a/src/integration-test/java/org/openlmis/referencedata/AuditLogInitializerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/AuditLogInitializerIntegrationTest.java
@@ -91,7 +91,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@ActiveProfiles({"test", "init-audit-log"})
+@ActiveProfiles({"test", "init-audit-log", "test-run"})
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @SuppressWarnings({"PMD.TooManyMethods"})

--- a/src/integration-test/java/org/openlmis/referencedata/JaVersIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/JaVersIntegrationTest.java
@@ -38,7 +38,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @SpringBootTest
 @Transactional
 public class JaVersIntegrationTest {

--- a/src/integration-test/java/org/openlmis/referencedata/repository/BaseCrudRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/repository/BaseCrudRepositoryIntegrationTest.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @Transactional
 public abstract class BaseCrudRepositoryIntegrationTest<T extends Identifiable> {
 

--- a/src/integration-test/java/org/openlmis/referencedata/service/DataImportServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/service/DataImportServiceIntegrationTest.java
@@ -69,7 +69,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {Application.class, DataImportService.class})
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @Transactional
 @SuppressWarnings({"PMD.TooManyMethods"})
 public class DataImportServiceIntegrationTest {

--- a/src/integration-test/java/org/openlmis/referencedata/web/BaseWebIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/web/BaseWebIntegrationTest.java
@@ -124,7 +124,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @SuppressWarnings({"PMD.TooManyMethods"})
 public abstract class BaseWebIntegrationTest {
 

--- a/src/main/java/org/openlmis/referencedata/TestDataInitializer.java
+++ b/src/main/java/org/openlmis/referencedata/TestDataInitializer.java
@@ -29,7 +29,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("demo-data")
+@Profile("demo-data & !test-run")
 @Order(5)
 public class TestDataInitializer implements CommandLineRunner {
   private static final XLogger XLOGGER = XLoggerFactory.getXLogger(TestDataInitializer.class);


### PR DESCRIPTION
Demo data was previously being loaded before the tests were run, so they were affected by records fetched from a csv.