### PR TITLE
HOTFIX/CQI-21: default parametrs set to int values for perf tests

### DIFF
--- a/performance/tests/approvedProducts.yml
+++ b/performance/tests/approvedProducts.yml
@@ -2,7 +2,7 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: approved-products
 
 scenarios:

--- a/performance/tests/approvedProducts.yml
+++ b/performance/tests/approvedProducts.yml
@@ -1,7 +1,7 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: approved-products
 

--- a/performance/tests/approvedProductsForEssentialMedsAndDistrictHospital.yml
+++ b/performance/tests/approvedProductsForEssentialMedsAndDistrictHospital.yml
@@ -2,7 +2,7 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: approved-products
 
 scenarios:

--- a/performance/tests/approvedProductsForEssentialMedsAndDistrictHospital.yml
+++ b/performance/tests/approvedProductsForEssentialMedsAndDistrictHospital.yml
@@ -1,7 +1,7 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: approved-products
 

--- a/performance/tests/facilities.yml
+++ b/performance/tests/facilities.yml
@@ -2,62 +2,62 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facility-create
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-minimal-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-minimal-one-page
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-audit-log
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facility-update
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-one
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-by-boundary-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-by-boundary-one-page
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-delete-one
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-search-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-search-one-page
 

--- a/performance/tests/facilities.yml
+++ b/performance/tests/facilities.yml
@@ -3,62 +3,62 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facility-create
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-minimal-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-minimal-one-page
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-audit-log
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facility-update
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-one
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-by-boundary-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-by-boundary-one-page
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-delete-one
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-get-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-search-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facilities-search-one-page
 
 scenarios:

--- a/performance/tests/facilityTypeApprovedProducts.yml
+++ b/performance/tests/facilityTypeApprovedProducts.yml
@@ -2,7 +2,7 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: ftaps-get-first-10
 
 scenarios:
@@ -10,7 +10,7 @@ scenarios:
     requests:
       - include-scenario: get-user-token
       - url: ${__P(base-uri)}/api/facilityTypeApprovedProducts?page=1&size=10&facilityType=dist_hosp&program=PRG002
-        method: GET
+        method: GET 
         label: GetAFacilityTypeApprovedProductsPageOfTen
         headers:
           Authorization: Bearer ${access_token}

--- a/performance/tests/facilityTypeApprovedProducts.yml
+++ b/performance/tests/facilityTypeApprovedProducts.yml
@@ -1,7 +1,7 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: ftaps-get-first-10
 

--- a/performance/tests/facilityUpdateAsync.yml
+++ b/performance/tests/facilityUpdateAsync.yml
@@ -2,7 +2,7 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: facility-update-async
 
 scenarios:

--- a/performance/tests/facilityUpdateAsync.yml
+++ b/performance/tests/facilityUpdateAsync.yml
@@ -1,7 +1,7 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: facility-update-async
 

--- a/performance/tests/idealStockAmounts.yml
+++ b/performance/tests/idealStockAmounts.yml
@@ -1,17 +1,17 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: download-ideal-stock-amounts-csv
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-ideal-stock-amounts
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: upload-ideal-stock-amounts-csv
 

--- a/performance/tests/idealStockAmounts.yml
+++ b/performance/tests/idealStockAmounts.yml
@@ -2,17 +2,17 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: download-ideal-stock-amounts-csv
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-ideal-stock-amounts
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: upload-ideal-stock-amounts-csv
 
 scenarios:

--- a/performance/tests/orderables.yml
+++ b/performance/tests/orderables.yml
@@ -2,27 +2,27 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-get-first-10
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-get-10-by-id
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-get-by-program-code-name
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-get-10000-by-program
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-search-10000-by-version-identities
 
 scenarios:

--- a/performance/tests/orderables.yml
+++ b/performance/tests/orderables.yml
@@ -1,27 +1,27 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-get-first-10
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-get-10-by-id
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-get-by-program-code-name
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-get-10000-by-program
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: orderables-search-10000-by-version-identities
 

--- a/performance/tests/processingPeriods.yml
+++ b/performance/tests/processingPeriods.yml
@@ -1,32 +1,32 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-processing-period
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-all-processing-periods
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: processing-periods-search
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-page-of-ten-processing-periods
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-processing-period-duration
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-processing-period-audit-log
 

--- a/performance/tests/processingPeriods.yml
+++ b/performance/tests/processingPeriods.yml
@@ -2,32 +2,32 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-processing-period
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-all-processing-periods
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: processing-periods-search
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-page-of-ten-processing-periods
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-processing-period-duration
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-processing-period-audit-log
 
 scenarios:

--- a/performance/tests/programs.yml
+++ b/performance/tests/programs.yml
@@ -2,22 +2,22 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: programs-get-one
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: programs-search
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: create-program
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: delete-program
 
 scenarios:

--- a/performance/tests/programs.yml
+++ b/performance/tests/programs.yml
@@ -1,22 +1,22 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: programs-get-one
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: programs-search
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: create-program
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: delete-program
 

--- a/performance/tests/supervisoryNodes.yml
+++ b/performance/tests/supervisoryNodes.yml
@@ -1,12 +1,12 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-all-supervisory-nodes
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-page-of-ten-supervisory-nodes
 

--- a/performance/tests/supervisoryNodes.yml
+++ b/performance/tests/supervisoryNodes.yml
@@ -2,12 +2,12 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-all-supervisory-nodes
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-page-of-ten-supervisory-nodes
 
 scenarios:

--- a/performance/tests/supplyLines.yml
+++ b/performance/tests/supplyLines.yml
@@ -2,37 +2,37 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-supply-line
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-all-supply-lines-expand
     # - concurrency: ${__P(scenario-concurrency,10)}
     # iterations: ${__P(scenario-iterations,10)}
     # ramp-up: ${__P(scenario-ramp-up,1m)}
-    # hold-for: ${__P(scenario-duration,10m)}
+    # hold-for: ${__P(scenario-duration,600)}
     # scenario: get-all-supply-lines
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-page-of-ten-supply-lines
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-page-of-ten-supply-lines-expand
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-supply-lines-by-supervisory-node-id
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: get-supply-lines-by-program-id-and-supplying-facility-id
 
 scenarios:

--- a/performance/tests/supplyLines.yml
+++ b/performance/tests/supplyLines.yml
@@ -1,37 +1,37 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-supply-line
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-all-supply-lines-expand
     # - concurrency: ${__P(scenario-concurrency,10)}
     # iterations: ${__P(scenario-iterations,10)}
-    # ramp-up: ${__P(scenario-ramp-up,1m)}
+    # ramp-up: ${__P(scenario-ramp-up,60)}
     # hold-for: ${__P(scenario-duration,600)}
     # scenario: get-all-supply-lines
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-page-of-ten-supply-lines
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-page-of-ten-supply-lines-expand
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-supply-lines-by-supervisory-node-id
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: get-supply-lines-by-program-id-and-supplying-facility-id
 

--- a/performance/tests/users.yml
+++ b/performance/tests/users.yml
@@ -1,67 +1,67 @@
 execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-search-one-page
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-has-right
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-permission-strings
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-programs
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-facilities
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: create-user
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: delete-user
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-supported-programs
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-fulfillment-facilities
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-role-assignments
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
-    ramp-up: 1m
+    ramp-up: 60
     hold-for: ${__P(scenario-duration,600)}
     scenario: users-search-by-right
 

--- a/performance/tests/users.yml
+++ b/performance/tests/users.yml
@@ -2,67 +2,67 @@ execution:
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-all
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-search-one-page
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-has-right
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-permission-strings
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-programs
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-facilities
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: create-user
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: delete-user
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-supported-programs
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-fulfillment-facilities
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-get-one-role-assignments
   - concurrency: ${__P(scenario-concurrency,10)}
     iterations: 10
     ramp-up: 1m
-    hold-for: ${__P(scenario-duration,10m)}
+    hold-for: ${__P(scenario-duration,600)}
     scenario: users-search-by-right
 
 scenarios:


### PR DESCRIPTION
Currently Jmeter runs the tests correctly but when it creates the report it comes up with the issue that the values from execution are not integers. Normally we use "1m", "10m" but those reports are designed to handle just integers values as seconds.