### PR TITLE
SELV3-780: add geo lvl names to demo data csv

### DIFF
--- a/src/main/resources/db/demo-data/referencedata.geographic_levels.csv
+++ b/src/main/resources/db/demo-data/referencedata.geographic_levels.csv
@@ -1,5 +1,5 @@
-id,code,levelnumber
-6b78e6c6-292e-4733-bb9c-3d802ad61206,Country,1
-9b497d87-cdd9-400e-bb04-fae0bf6a9491,Region,2
-93c05138-4550-4461-9e8a-79d5f050c223,District,3
-90e35999-a64f-4312-ba8f-bc13a1311c75,City,4
+id,code,levelnumber,name
+6b78e6c6-292e-4733-bb9c-3d802ad61206,Country,1,Country
+9b497d87-cdd9-400e-bb04-fae0bf6a9491,Region,2,Region
+93c05138-4550-4461-9e8a-79d5f050c223,District,3,District
+90e35999-a64f-4312-ba8f-bc13a1311c75,City,4,City


### PR DESCRIPTION
[SELV3-780](https://openlmis.atlassian.net/browse/SELV3-780)

Changes:
- Since FE is based on Geographic Level name, we need to make sure that name on UAT is not null.

[SELV3-780]: https://openlmis.atlassian.net/browse/SELV3-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ