### PR TITLE
OLMIS-8072: Add export functionality for geographic zones to complete catchment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 15.3.0 / wip
 ==================
 
+New functionality:
+* [OLMIS-8072](https://openlmis.atlassian.net/browse/OLMIS-8072): Add functionality to export geographic zone codes with their catchment population.
+
 15.2.9 / 2025-01-14
 ==================
 

--- a/src/main/java/org/openlmis/referencedata/dto/GeographicZoneSimpleDto.java
+++ b/src/main/java/org/openlmis/referencedata/dto/GeographicZoneSimpleDto.java
@@ -43,7 +43,7 @@ import org.openlmis.referencedata.web.csv.processor.CsvCellProcessors;
 public class GeographicZoneSimpleDto extends BaseDto implements
     GeographicZone.Exporter, GeographicZone.Importer {
 
-  @ImportField(name = "code")
+  @ImportField(name = "code", mandatory = true)
   private String code;
 
   private String name;
@@ -102,5 +102,18 @@ public class GeographicZoneSimpleDto extends BaseDto implements
   public Map<String, Object> getExtraData() {
     // unsupported operation
     return Maps.newHashMap();
+  }
+
+  /**
+   * Create new instance of GeographicZoneSimpleDto.
+   *
+   * @param geographicZone a geographicZone to create model from, not null
+   * @return new instance of GeographicZoneSimpleDto, never null
+   */
+  public static GeographicZoneSimpleDto newInstance(GeographicZone geographicZone) {
+    final GeographicZoneSimpleDto model = new GeographicZoneSimpleDto();
+    model.code = geographicZone.getCode();
+    model.catchmentPopulation = geographicZone.getCatchmentPopulation();
+    return model;
   }
 }

--- a/src/main/java/org/openlmis/referencedata/service/GeographicZoneService.java
+++ b/src/main/java/org/openlmis/referencedata/service/GeographicZoneService.java
@@ -16,17 +16,24 @@
 package org.openlmis.referencedata.service;
 
 import com.google.common.collect.Sets;
+
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openlmis.referencedata.domain.GeographicLevel;
 import org.openlmis.referencedata.domain.GeographicZone;
+import org.openlmis.referencedata.dto.GeographicZoneSimpleDto;
 import org.openlmis.referencedata.exception.ValidationMessageException;
 import org.openlmis.referencedata.repository.GeographicLevelRepository;
 import org.openlmis.referencedata.repository.GeographicZoneRepository;
+import org.openlmis.referencedata.service.export.ExportableDataService;
 import org.openlmis.referencedata.util.Message;
 import org.openlmis.referencedata.util.UuidUtil;
 import org.openlmis.referencedata.util.messagekeys.GeographicLevelMessageKeys;
@@ -37,7 +44,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
-public class GeographicZoneService {
+public class GeographicZoneService implements
+        ExportableDataService<GeographicZoneSimpleDto> {
 
   static final String NAME = "name";
   static final String CODE = "code";
@@ -124,5 +132,17 @@ public class GeographicZoneService {
       }
     }
     return level;
+  }
+
+  @Override
+  public List<GeographicZoneSimpleDto> findAllExportableItems() {
+    return StreamSupport.stream(geographicZoneRepository.findAll().spliterator(), false)
+        .map(GeographicZoneSimpleDto::newInstance)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Class<GeographicZoneSimpleDto> getExportableType() {
+    return GeographicZoneSimpleDto.class;
   }
 }

--- a/src/main/java/org/openlmis/referencedata/service/export/DataImportService.java
+++ b/src/main/java/org/openlmis/referencedata/service/export/DataImportService.java
@@ -43,7 +43,7 @@ public class DataImportService {
           "orderable.csv",
           "programOrderable.csv",
           "tradeItem.csv",
-          "geographicZones.csv");
+          "geographicZone.csv");
 
   @Autowired private FileHelper fileHelper;
   @Autowired private BeanFactory beanFactory;

--- a/src/main/java/org/openlmis/referencedata/service/export/GeographicZonesImportPersister.java
+++ b/src/main/java/org/openlmis/referencedata/service/export/GeographicZonesImportPersister.java
@@ -41,7 +41,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-@Service("geographicZones.csv")
+@Service("geographicZone.csv")
 public class GeographicZonesImportPersister
     implements DataImportPersister<GeographicZone, GeographicZoneDto, GeographicZoneDto> {
 

--- a/src/main/resources/data-export/mapping/csv/geographicZone_mapping.csv
+++ b/src/main/resources/data-export/mapping/csv/geographicZone_mapping.csv
@@ -1,0 +1,3 @@
+from,to,type,entityName,defaultValue
+code,code,DIRECT,,
+catchmentpopulation,catchmentPopulation,DIRECT,,

--- a/src/test/java/org/openlmis/referencedata/dto/GeographicZoneSimpleDtoTest.java
+++ b/src/test/java/org/openlmis/referencedata/dto/GeographicZoneSimpleDtoTest.java
@@ -15,10 +15,14 @@
 
 package org.openlmis.referencedata.dto;
 
+import static org.junit.Assert.assertEquals;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.openlmis.referencedata.ToStringTestUtils;
+import org.openlmis.referencedata.domain.GeographicZone;
+import org.openlmis.referencedata.testbuilder.GeographicZoneDataBuilder;
 
 public class GeographicZoneSimpleDtoTest {
 
@@ -39,6 +43,15 @@ public class GeographicZoneSimpleDtoTest {
   public void shouldImplementToString() {
     GeographicZoneSimpleDto dto = new GeographicZoneSimpleDto();
     ToStringTestUtils.verify(GeographicZoneSimpleDto.class, dto);
+  }
+
+  @Test
+  public void shouldCreateNewInstance() {
+    GeographicZone geographicZone = new GeographicZoneDataBuilder().buildAsNew();
+    GeographicZoneSimpleDto dto = GeographicZoneSimpleDto.newInstance(geographicZone);
+
+    assertEquals(geographicZone.getCode(), dto.getCode());
+    assertEquals(geographicZone.getCatchmentPopulation(), dto.getCatchmentPopulation());
   }
 
 }

--- a/src/test/java/org/openlmis/referencedata/service/GeographicZoneServiceTest.java
+++ b/src/test/java/org/openlmis/referencedata/service/GeographicZoneServiceTest.java
@@ -17,6 +17,7 @@ package org.openlmis.referencedata.service;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -30,12 +31,15 @@ import static org.openlmis.referencedata.service.GeographicZoneService.PARENT;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
+import org.hamcrest.core.Every;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,6 +49,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.openlmis.referencedata.domain.GeographicLevel;
 import org.openlmis.referencedata.domain.GeographicZone;
+import org.openlmis.referencedata.dto.GeographicZoneSimpleDto;
 import org.openlmis.referencedata.exception.ValidationMessageException;
 import org.openlmis.referencedata.repository.GeographicLevelRepository;
 import org.openlmis.referencedata.repository.GeographicZoneRepository;
@@ -181,5 +186,21 @@ public class GeographicZoneServiceTest {
     Set<UUID> actual = geographicZoneService.getAllZonesInHierarchy(parentId);
     assertThat(actual, hasSize(expected.length));
     assertThat(actual, hasItems(expected));
+  }
+
+  @Test
+  public void shouldReturnAllGeographicZones() {
+    final Integer geographicZoneListSize = geographicZones.size();
+    when(geographicZoneRepository.findAll()).thenReturn(geographicZones);
+    List<GeographicZoneSimpleDto> result = geographicZoneService.findAllExportableItems();
+    assertEquals(Integer.valueOf(result.size()), geographicZoneListSize);
+  }
+
+  @Test
+  public void shouldReturnTypeThatMatchesTypeOfFoundItems() {
+    when(geographicZoneRepository.findAll()).thenReturn(geographicZones);
+    List<GeographicZoneSimpleDto> resultList = geographicZoneService.findAllExportableItems();
+    Class<?> resultType = geographicZoneService.getExportableType();
+    assertThat(resultList, Every.everyItem(instanceOf(resultType)));
   }
 }


### PR DESCRIPTION
It is now possible to export file with geographic zones codes and their catchment population, which can be later used in import after editing values. 

Changed naming of imported file from `geographicZones.csv` to `geographicZone.csv` to unify it with other imports and file name which is being exported. 