### PR TITLE
OE-87: New repeatebale `exectCode` query parameter tofilter by exact orderable/lot codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Improvements:
  query parameters
 * [OE-86](https://openlmis.atlassian.net/browse/OE-86): GET /programs has new program code repeatable query parameter
 * [OLMIS-8099](https://openlmis.atlassian.net/browse/OLMIS-8099): Delete unsed report rights, create new superset report rights
+* [OE-87](https://openlmis.atlassian.net/browse/OE-87): GET /orderables and /lots have new repeatebale `exectCode` query
+ parameter to filter by exact codes (opposed to `code` doing contains condition)
 
 Bux fixes:
 * [OLMIS-8068](https://openlmis.atlassian.net/browse/OLMIS-8068): Fix NPE on adding programs to products

--- a/src/integration-test/java/org/openlmis/referencedata/repository/LotRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/repository/LotRepositoryIntegrationTest.java
@@ -15,17 +15,19 @@
 
 package org.openlmis.referencedata.repository;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.openlmis.referencedata.domain.Lot;
 import org.openlmis.referencedata.domain.TradeItem;
+import org.openlmis.referencedata.repository.lot.LotRepositorySearchParams;
 import org.openlmis.referencedata.testbuilder.LotDataBuilder;
 import org.openlmis.referencedata.testbuilder.TradeItemDataBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,15 +85,11 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
   public void shouldFindLotsWithSimilarCode() {
     Lot expected = lotRepository.save(generateInstance());
 
-    Page<Lot> lotPage = lotRepository.search(
-        null,
-        null,
-        expected.getLotCode(),
-        null,
-        null,
-        null,
-        pageRequest
-    );
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(
+                null, null, null, expected.getLotCode(), null, null, null),
+            pageRequest);
 
     assertEquals(1, lotPage.getNumberOfElements());
     assertEquals(expected, lotPage.getContent().get(0));
@@ -104,15 +102,10 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
     lotTwo.setLotCode(lotOne.getLotCode());
     lotRepository.save(lotTwo);
 
-    Page<Lot> lotPage = lotRepository.search(
-        null,
-        null,
-        lotOne.getLotCode(),
-        null,
-        null,
-        null,
-        pageRequest
-    );
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(null, null, null, lotOne.getLotCode(), null, null, null),
+            pageRequest);
 
     assertEquals(2, lotPage.getNumberOfElements());
     assertEquals(lotOne, lotPage.getContent().get(0));
@@ -125,7 +118,9 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
     expected.setExpirationDate(now);
     expected = lotRepository.save(expected);
 
-    Page<Lot> lotPage = lotRepository.search(null, now, null, null, null, null, pageRequest);
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(null, now, null, null, null, null, null), pageRequest);
 
     assertEquals(1, lotPage.getNumberOfElements());
     assertEquals(expected, lotPage.getContent().get(0));
@@ -135,15 +130,17 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
   public void shouldFindLotsByTradeItem() {
     Lot expected = lotRepository.save(generateInstance());
 
-    Page<Lot> lotPage = lotRepository.search(
-        Collections.singletonList(expected.getTradeItem()),
-        null,
-        null,
-        null,
-        null,
-        null,
-        pageRequest
-    );
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(
+                singleton(expected.getTradeItem()),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null),
+            pageRequest);
 
     assertEquals(1, lotPage.getNumberOfElements());
     assertEquals(expected, lotPage.getContent().get(0));
@@ -154,15 +151,17 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
     Lot expected = lotRepository.save(generateInstance());
     Lot expected2 = lotRepository.save(generateInstance());
 
-    Page<Lot> lotPage = lotRepository.search(
-        ImmutableList.of(expected.getTradeItem(), expected2.getTradeItem()),
-        null,
-        null,
-        null,
-        null,
-        null,
-        pageRequest
-    );
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(
+                ImmutableSet.of(expected.getTradeItem(), expected2.getTradeItem()),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null),
+            pageRequest);
 
     assertEquals(2, lotPage.getNumberOfElements());
     assertEquals(expected, lotPage.getContent().get(0));
@@ -171,15 +170,10 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
 
   @Test
   public void shouldFindAllLotsIfSearchByEmptyTradeItemList() {
-    Page<Lot> lotPage = lotRepository.search(
-        Collections.emptyList(),
-        null,
-        null,
-        null,
-        null,
-        null,
-        pageRequest
-    );
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(emptySet(), null, null, null, null, null, null),
+            pageRequest);
 
     assertEquals(5, lotPage.getNumberOfElements());
   }
@@ -188,15 +182,17 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
   public void shouldFindLotsByAllParameters() {
     Lot expected = lotRepository.save(generateInstance());
 
-    Page<Lot> lotPage = lotRepository.search(
-        Collections.singletonList(expected.getTradeItem()),
-        expected.getExpirationDate(),
-        expected.getLotCode(),
-        Collections.singletonList(expected.getId()),
-        null,
-        null,
-        pageRequest
-    );
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(
+                singleton(expected.getTradeItem()),
+                expected.getExpirationDate(),
+                null,
+                expected.getLotCode(),
+                singleton(expected.getId()),
+                null,
+                null),
+            pageRequest);
 
     assertEquals(1, lotPage.getNumberOfElements());
     assertEquals(expected, lotPage.getContent().get(0));
@@ -210,15 +206,17 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
     Lot instanceTwo = generateInstance();
     repository.save(instanceTwo);
 
-    Page<Lot> lotPage = lotRepository.search(
-        null,
-        null,
-        null,
-        Arrays.asList(instanceOne.getId(), instanceTwo.getId()),
-        null,
-        null,
-        pageRequest
-    );
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(
+                null,
+                null,
+                null,
+                null,
+                ImmutableSet.of(instanceOne.getId(), instanceTwo.getId()),
+                null,
+                null),
+            pageRequest);
 
     assertEquals(2, lotPage.getNumberOfElements());
     assertEquals(lotPage.getContent(), Arrays.asList(instanceOne, instanceTwo));
@@ -226,7 +224,9 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
 
   @Test
   public void shouldReturnAllIfNoParamIsGiven() {
-    Page<Lot> lotPage = lotRepository.search(null, null, null, null, null, null, pageRequest);
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(null, null, null, null, null, null, null), pageRequest);
 
     assertEquals(5, lotPage.getNumberOfElements());
   }
@@ -266,15 +266,10 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
     entity.setExpirationDate(date);
     lotRepository.save(entity);
 
-    Page<Lot> lotPage = lotRepository.search(
-        null,
-        null,
-        entity.getLotCode(),
-        null,
-        null,
-        null,
-        pageRequest
-    );
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(null, null, null, entity.getLotCode(), null, null, null),
+            pageRequest);
 
     assertEquals(1, lotPage.getNumberOfElements());
     assertEquals(date, lotPage.getContent().get(0).getExpirationDate());
@@ -284,15 +279,9 @@ public class LotRepositoryIntegrationTest extends BaseCrudRepositoryIntegrationT
   public void shouldRespectPaginationParameters() {
     Pageable pageable = PageRequest.of(1, 3);
 
-    Page<Lot> lotPage = lotRepository.search(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        pageable
-    );
+    Page<Lot> lotPage =
+        lotRepository.search(
+            new LotRepositorySearchParams(null, null, null, null, null, null, null), pageable);
 
     assertEquals(2, lotPage.getNumberOfElements());
     assertEquals(lotOne, lotPage.getContent().get(0));

--- a/src/integration-test/java/org/openlmis/referencedata/web/LotControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/web/LotControllerIntegrationTest.java
@@ -23,11 +23,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -52,6 +51,7 @@ import org.openlmis.referencedata.domain.RightName;
 import org.openlmis.referencedata.domain.TradeItem;
 import org.openlmis.referencedata.dto.LotDto;
 import org.openlmis.referencedata.exception.UnauthorizedException;
+import org.openlmis.referencedata.repository.lot.LotRepositorySearchParams;
 import org.openlmis.referencedata.service.PageDto;
 import org.openlmis.referencedata.testbuilder.LotDataBuilder;
 import org.openlmis.referencedata.util.Message;
@@ -95,7 +95,7 @@ public class LotControllerIntegrationTest extends BaseWebIntegrationTest {
   public void shouldCreateNewLot() {
     mockUserHasRight(LOTS_MANAGE);
 
-    given(lotRepository.search(null, null, lot.getLotCode(), null, null, null, null))
+    given(lotRepository.search(any(LotRepositorySearchParams.class), any(Pageable.class)))
         .willReturn(Pagination.getPage(Collections.emptyList(), PageRequest.of(0, 10)));
 
     LotDto response = restAssured
@@ -161,7 +161,12 @@ public class LotControllerIntegrationTest extends BaseWebIntegrationTest {
     mockUserHasRight(LOTS_MANAGE);
     when(lotRepository.findById(lotId)).thenReturn(Optional.of(lot));
 
-    given(lotRepository.search(null, null, lot.getLotCode(), null, null, null, null))
+    given(
+            lotRepository.search(
+                eq(
+                    new LotRepositorySearchParams(
+                        null, null, null, lot.getLotCode(), null, null, null)),
+                any(Pageable.class)))
         .willReturn(Pagination.getPage(Collections.singletonList(lot), PageRequest.of(0, 10)));
 
     LotDto response = restAssured
@@ -225,10 +230,9 @@ public class LotControllerIntegrationTest extends BaseWebIntegrationTest {
 
   @Test
   public void shouldFindLots() {
-    given(lotRepository.search(anyList(), any(LocalDate.class), anyString(),
-        nullable(List.class), any(LocalDate.class), any(LocalDate.class), any(Pageable.class)))
+    given(lotRepository.search(any(LotRepositorySearchParams.class), any(Pageable.class)))
         .willReturn(Pagination.getPage(singletonList(lot), pageable));
-    when(tradeItemRepository.findAllById(anyList()))
+    when(tradeItemRepository.findAllById(anySet()))
         .thenReturn(Collections.singletonList(new TradeItem()));
 
     String expirationDate = lot.getExpirationDate().format(DateTimeFormatter.ISO_DATE);
@@ -380,15 +384,8 @@ public class LotControllerIntegrationTest extends BaseWebIntegrationTest {
         new LotDataBuilder().build()
     );
 
-    given(lotRepository.search(
-        eq(emptyList()),
-        eq(null),
-        eq(null),
-        eq(Arrays.asList(lots.get(0).getId(), lots.get(1).getId())),
-        eq(null),
-        eq(null),
-        any(Pageable.class)
-    )).willReturn(Pagination.getPage(lots, PageRequest.of(0, 10)));
+    given(lotRepository.search(any(LotRepositorySearchParams.class), any(Pageable.class)))
+        .willReturn(Pagination.getPage(lots, PageRequest.of(0, 10)));
 
     PageDto response = restAssured
         .given()
@@ -412,15 +409,8 @@ public class LotControllerIntegrationTest extends BaseWebIntegrationTest {
         new LotDataBuilder().build()
     );
 
-    given(lotRepository.search(
-        eq(emptyList()),
-        eq(null),
-        eq(null),
-        eq(null),
-        eq(null),
-        eq(null),
-        eq(PageRequest.of(0, 2))
-    )).willReturn(Pagination.getPage(lots, PageRequest.of(0, 2)));
+    given(lotRepository.search(any(LotRepositorySearchParams.class), eq(PageRequest.of(0, 2))))
+        .willReturn(Pagination.getPage(lots, PageRequest.of(0, 2)));
 
     PageDto response = restAssured
         .given()

--- a/src/main/java/org/openlmis/referencedata/repository/custom/LotRepositoryCustom.java
+++ b/src/main/java/org/openlmis/referencedata/repository/custom/LotRepositoryCustom.java
@@ -16,8 +16,7 @@
 package org.openlmis.referencedata.repository.custom;
 
 import java.time.LocalDate;
-import java.util.Collection;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.openlmis.referencedata.domain.Lot;
 import org.openlmis.referencedata.domain.TradeItem;
@@ -26,13 +25,21 @@ import org.springframework.data.domain.Pageable;
 
 public interface LotRepositoryCustom {
 
-  Page<Lot> search(
-          Collection<TradeItem> tradeItems,
-          LocalDate expirationDate,
-          String code,
-          List<UUID> ids,
-          LocalDate expirationDateFrom,
-          LocalDate expirationDateTo,
-          Pageable pageable
-  );
+  Page<Lot> search(SearchParams searchParams, Pageable pageable);
+
+  interface SearchParams {
+    Set<TradeItem> getTradeItems();
+
+    LocalDate getExpirationDate();
+
+    Set<String> getExactCodes();
+
+    String getCode();
+
+    Set<UUID> getIds();
+
+    LocalDate getExpirationDateFrom();
+
+    LocalDate getExpirationDateTo();
+  }
 }

--- a/src/main/java/org/openlmis/referencedata/repository/custom/OrderableRepositoryCustom.java
+++ b/src/main/java/org/openlmis/referencedata/repository/custom/OrderableRepositoryCustom.java
@@ -30,6 +30,7 @@ public interface OrderableRepositoryCustom {
   ZonedDateTime findLatestModifiedDateByParams(SearchParams searchParams);
 
   interface SearchParams {
+    Set<String> getExactCodes();
 
     String getCode();
 
@@ -40,6 +41,5 @@ public interface OrderableRepositoryCustom {
     Set<Pair<UUID, Long>> getIdentityPairs();
 
     Set<UUID> getTradeItemId();
-
   }
 }

--- a/src/main/java/org/openlmis/referencedata/repository/lot/LotRepositorySearchParams.java
+++ b/src/main/java/org/openlmis/referencedata/repository/lot/LotRepositorySearchParams.java
@@ -13,37 +13,26 @@
  * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
  */
 
-package org.openlmis.referencedata.service;
+package org.openlmis.referencedata.repository.lot;
 
 import java.time.LocalDate;
 import java.util.Set;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.format.annotation.DateTimeFormat;
+import org.openlmis.referencedata.domain.TradeItem;
+import org.openlmis.referencedata.repository.custom.LotRepositoryCustom;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
-public class LotSearchParams {
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-  private LocalDate expirationDate;
-
-  private Set<UUID> tradeItemId;
-  private Set<String> exactCode;
-  private String lotCode;
-  private Set<UUID> id;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-  private LocalDate expirationDateFrom;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-  private LocalDate expirationDateTo;
-
-  private Set<UUID> orderableId;
-  private boolean isTradeItemIdIgnored = false;
+@EqualsAndHashCode
+public class LotRepositorySearchParams implements LotRepositoryCustom.SearchParams {
+  private final Set<TradeItem> tradeItems;
+  private final LocalDate expirationDate;
+  private final Set<String> exactCodes;
+  private final String code;
+  private final Set<UUID> ids;
+  private final LocalDate expirationDateFrom;
+  private final LocalDate expirationDateTo;
 }

--- a/src/main/java/org/openlmis/referencedata/web/OrderableController.java
+++ b/src/main/java/org/openlmis/referencedata/web/OrderableController.java
@@ -72,6 +72,7 @@ public class OrderableController extends BaseController {
   private static final XLogger XLOGGER = XLoggerFactory.getXLogger(OrderableController.class);
   private static final String NAME = "name";
   private static final String CODE = "code";
+  private static final String EXACT_CODE = "exactCode";
   private static final String PROGRAM_CODE = "program";
 
   @Autowired
@@ -374,6 +375,7 @@ public class OrderableController extends BaseController {
       }
     }
     queryMap.add(NAME, searchParams.getName());
+    queryMap.add(EXACT_CODE, searchParams.getExactCodes());
     queryMap.add(CODE, searchParams.getCode());
     queryMap.add(PROGRAM_CODE, searchParams.getProgramCode());
 

--- a/src/main/java/org/openlmis/referencedata/web/OrderableSearchParams.java
+++ b/src/main/java/org/openlmis/referencedata/web/OrderableSearchParams.java
@@ -15,8 +15,10 @@
 
 package org.openlmis.referencedata.web;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -56,6 +58,11 @@ public final class OrderableSearchParams
   }
 
   @Override
+  public Set<String> getExactCodes() {
+    return emptySet();
+  }
+
+  @Override
   @JsonIgnore
   String getInvalidVersionIdentityErrorMessage() {
     return OrderableMessageKeys.ERROR_INVALID_VERSION_IDENTITY;
@@ -63,12 +70,12 @@ public final class OrderableSearchParams
 
   @Override
   public Set<UUID> getTradeItemId() {
-    return Collections.emptySet();
+    return emptySet();
   }
 
   @Override
   @JsonIgnore
   public Set<String> getProgramCodes() {
-    return Collections.singleton(programCode);
+    return singleton(programCode);
   }
 }

--- a/src/main/java/org/openlmis/referencedata/web/QueryOrderableSearchParams.java
+++ b/src/main/java/org/openlmis/referencedata/web/QueryOrderableSearchParams.java
@@ -37,13 +37,14 @@ import org.springframework.util.MultiValueMap;
 public class QueryOrderableSearchParams implements OrderableRepositoryCustom.SearchParams {
 
   private static final String CODE = "code";
+  private static final String EXACT_CODE = "exactCode";
   private static final String NAME = "name";
   private static final String PROGRAM_CODE = "program";
   private static final String TRADE_ITEM_ID = "tradeItemId";
   private static final String ID = "id";
 
   private static final List<String> ALL_PARAMETERS = Collections.unmodifiableList(Arrays.asList(
-      ID, CODE, NAME, PROGRAM_CODE, TRADE_ITEM_ID));
+      ID, EXACT_CODE, CODE, NAME, PROGRAM_CODE, TRADE_ITEM_ID));
 
   private final SearchParams queryParams;
 
@@ -57,10 +58,24 @@ public class QueryOrderableSearchParams implements OrderableRepositoryCustom.Sea
   }
 
   /**
+   * Gets exact orderables codes. Specifies a list of exact orderables codes to filter upon. This
+   * condition precedes `code` condition.
+   *
+   * @return String value of code or null if params doesn't contain "code" param. Empty string for
+   *     null request param value.
+   * @see #getCode()
+   */
+  @Override
+  public Set<String> getExactCodes() {
+    return queryParams.getStrings(EXACT_CODE);
+  }
+
+  /**
    * Gets code.
    *
    * @return String value of code or null if params doesn't contain "code" param. Empty string
    *         for null request param value.
+   * @see #getExactCodes()
    */
   @Override
   public String getCode() {

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -756,8 +756,13 @@ resourceTypes:
                   type: string
                   required: false
                   repeat: true
+              exactCode:
+                displayName: exact orderable code
+                type: string
+                required: false
+                repeat: true
               code:
-                  displayName: orderable code
+                  displayName: like orderable code
                   type: string
                   required: false
                   repeat: false
@@ -3558,6 +3563,11 @@ resourceTypes:
                   type: string
                   required: false
                   repeat: false
+              exactCode:
+                  displayName: exact lot code
+                  type: string
+                  required: false
+                  repeat: true
               lotCode:
                   displayName: lotCode
                   description: The code of the Lot.

--- a/src/test/java/org/openlmis/referencedata/repository/lot/LotRepositorySearchParamsTest.java
+++ b/src/test/java/org/openlmis/referencedata/repository/lot/LotRepositorySearchParamsTest.java
@@ -15,24 +15,17 @@
 
 package org.openlmis.referencedata.repository.lot;
 
-import java.time.LocalDate;
-import java.util.Set;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
 import org.openlmis.referencedata.domain.TradeItem;
-import org.openlmis.referencedata.repository.custom.LotRepositoryCustom;
+import org.openlmis.referencedata.testbuilder.TradeItemDataBuilder;
 
-@Getter
-@AllArgsConstructor
-@EqualsAndHashCode
-public final class LotRepositorySearchParams implements LotRepositoryCustom.SearchParams {
-  private final Set<TradeItem> tradeItems;
-  private final LocalDate expirationDate;
-  private final Set<String> exactCodes;
-  private final String code;
-  private final Set<UUID> ids;
-  private final LocalDate expirationDateFrom;
-  private final LocalDate expirationDateTo;
+public class LotRepositorySearchParamsTest {
+  @Test
+  public void testEqualsContract() {
+    EqualsVerifier.forClass(LotRepositorySearchParams.class)
+        .withPrefabValues(
+            TradeItem.class, new TradeItemDataBuilder().build(), new TradeItemDataBuilder().build())
+        .verify();
+  }
 }

--- a/src/test/java/org/openlmis/referencedata/service/LotServiceTest.java
+++ b/src/test/java/org/openlmis/referencedata/service/LotServiceTest.java
@@ -16,17 +16,17 @@
 package org.openlmis.referencedata.service;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
+import java.util.ArrayList;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,6 +40,7 @@ import org.openlmis.referencedata.domain.TradeItem;
 import org.openlmis.referencedata.exception.ValidationMessageException;
 import org.openlmis.referencedata.repository.LotRepository;
 import org.openlmis.referencedata.repository.TradeItemRepository;
+import org.openlmis.referencedata.repository.lot.LotRepositorySearchParams;
 import org.openlmis.referencedata.testbuilder.LotDataBuilder;
 import org.openlmis.referencedata.testbuilder.TradeItemDataBuilder;
 import org.openlmis.referencedata.util.Pagination;
@@ -81,31 +82,34 @@ public class LotServiceTest {
 
   @Test
   public void searchShouldReturnRepositoryResult() {
-    List<UUID> tradeItemIds = singletonList(tradeItem.getId());
-    LotSearchParams lotSearchParams = new LotSearchParams(
-        LocalDate.now(),
-        tradeItemIds,
-        lot.getLotCode(),
-        ImmutableList.of(lot.getId()),
-        null,
-        null,
-        Collections.emptyList(),
-            false
-    );
+    Set<UUID> tradeItemIds = singleton(tradeItem.getId());
+    LotSearchParams lotSearchParams =
+        new LotSearchParams(
+            LocalDate.now(),
+            tradeItemIds,
+            null,
+            lot.getLotCode(),
+            singleton(lot.getId()),
+            null,
+            null,
+            emptySet(),
+            false);
 
-    List<TradeItem> tradeItems = singletonList(tradeItem);
+    Set<TradeItem> tradeItems = singleton(tradeItem);
     when(tradeItemRepository.findAllById(tradeItemIds))
-        .thenReturn(tradeItems);
+        .thenReturn(new ArrayList<>(tradeItems));
 
     when(lotRepository.search(
-        tradeItems,
-        lotSearchParams.getExpirationDate(),
-        lotSearchParams.getLotCode(),
-        lotSearchParams.getId(),
-        null,
-        null,
-        pageable
-    )).thenReturn(expected);
+            new LotRepositorySearchParams(
+                tradeItems,
+                lotSearchParams.getExpirationDate(),
+                null,
+                lotSearchParams.getLotCode(),
+                lotSearchParams.getId(),
+                null,
+                null),
+            pageable))
+        .thenReturn(expected);
 
     Page<Lot> result = lotService.search(lotSearchParams, pageable);
 
@@ -117,23 +121,26 @@ public class LotServiceTest {
     LotSearchParams lotSearchParams = new LotSearchParams(
         LocalDate.now(),
         null,
+        null,
         lot.getLotCode(),
         null,
         null,
         null,
-        Collections.emptyList(),
+        emptySet(),
             false
     );
 
     when(lotRepository.search(
-        eq(emptyList()),
-        eq(lotSearchParams.getExpirationDate()),
-        eq(lotSearchParams.getLotCode()),
-        eq(null),
-        eq(null),
-        eq(null),
-        eq(pageable)
-    )).thenReturn(expected);
+            new LotRepositorySearchParams(
+                emptySet(),
+                lotSearchParams.getExpirationDate(),
+                null,
+                lotSearchParams.getLotCode(),
+                null,
+                null,
+                null),
+            pageable))
+        .thenReturn(expected);
 
     Page<Lot> result = lotService.search(lotSearchParams, pageable);
 
@@ -142,13 +149,14 @@ public class LotServiceTest {
 
   @Test
   public void searchShouldReturnEmptyListIfTradeItemDoesNotExist() {
-    when(tradeItemRepository.findAllById(singletonList(tradeItem.getId()))).thenReturn(emptyList());
+    when(tradeItemRepository.findAllById(singleton(tradeItem.getId()))).thenReturn(emptyList());
 
     LotSearchParams lotSearchParams = new LotSearchParams(
         LocalDate.now(),
-        singletonList(tradeItem.getId()),
+        singleton(tradeItem.getId()),
+        emptySet(),
         lot.getLotCode(),
-        ImmutableList.of(lot.getId()),
+        singleton(lot.getId()),
             null,
             null,
             null,
@@ -166,26 +174,19 @@ public class LotServiceTest {
 
   @Test
   public void searchShouldNotThrowExceptionIfRequestParamsAreNotGiven() {
-    when(lotRepository.search(
-            emptyList(),
+    when(lotRepository.search(new LotRepositorySearchParams(
+            emptySet(),
             null,
             null,
             null,
             null,
             null,
+            null),
             pageable
     )).thenReturn(expected);
 
-    LotSearchParams lotSearchParams = new LotSearchParams(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            true
-    );
+    LotSearchParams lotSearchParams =
+        new LotSearchParams(null, null, null, null, null, null, null, null, true);
 
     Page<Lot> result = lotService.search(lotSearchParams, pageable);
     assertThat(result.getContent(), hasSize(1));
@@ -193,16 +194,17 @@ public class LotServiceTest {
 
   @Test(expected = ValidationMessageException.class)
   public void searchShouldThrowValidationExceptionWhenTradeItemIdAndOrderableIdIsSet() {
-    LotSearchParams lotSearchParams = new LotSearchParams(
+    LotSearchParams lotSearchParams =
+        new LotSearchParams(
             null,
-            singletonList(UUID.randomUUID()),
+            singleton(UUID.randomUUID()),
             null,
             null,
             null,
             null,
-            singletonList(UUID.randomUUID()),
-            false
-    );
+            null,
+            singleton(UUID.randomUUID()),
+            false);
 
     Page<Lot> result = lotService.search(lotSearchParams, pageable);
     assertThat(result.getContent(), hasSize(0));

--- a/src/test/java/org/openlmis/referencedata/testbuilder/TradeItemDataBuilder.java
+++ b/src/test/java/org/openlmis/referencedata/testbuilder/TradeItemDataBuilder.java
@@ -39,6 +39,17 @@ public class TradeItemDataBuilder {
   }
 
   /**
+   * Set Id.
+   *
+   * @param id the id
+   * @return this builder, never null
+   */
+  public TradeItemDataBuilder withId(UUID id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
    * Add classification based on data from {@link CommodityType}.
    */
   public TradeItemDataBuilder withClassification(CommodityType type) {


### PR DESCRIPTION
This adds `exactCode` repeatable URL query parameter to search by exact codes.
The existing `code` functionality is retained, a search by orderables/lots that code contains text in `code` parameter, that is more useful for FE.