### PR TITLE
OLMIS-8118: Reject kit quantity exceeding Integer max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+15.6.0-SNAPSHOT (WIP)
+==================
+* [OLMIS-8118](https://openlmis.atlassian.net/browse/OLMIS-8118): Reject kit child quantity exceeding Integer max.
+
 15.5.0 / 2026-06-09
 ==================
 

--- a/src/main/java/org/openlmis/referencedata/util/messagekeys/OrderableMessageKeys.java
+++ b/src/main/java/org/openlmis/referencedata/util/messagekeys/OrderableMessageKeys.java
@@ -22,6 +22,9 @@ public abstract class OrderableMessageKeys extends MessageKeys {
   private static final String NOT_SUPPORTED = "notSupported";
   private static final String NEGATIVE_PRICE_PER_PACK = "negativePricePerPackNotAllowed";
   private static final String PRODUCT_CODE = "productCode";
+  private static final String CHILD = "child";
+  private static final String QUANTITY = "quantity";
+  private static final String TOO_LARGE = "tooLarge";
 
   public static final String ERROR_NOT_FOUND = join(ERROR, NOT_FOUND);
   public static final String ERROR_NULL = join(ERROR, NULL);
@@ -80,4 +83,6 @@ public abstract class OrderableMessageKeys extends MessageKeys {
   public static final String ERROR_NEGATIVE_PRICE_PER_PACK = join(ERROR, NEGATIVE_PRICE_PER_PACK);
   public static final String ERROR_PRODUCT_CODE_MUST_BE_UNIQUE =
           join(ERROR, PRODUCT_CODE, MUST_BE_UNIQUE);
+  public static final String ERROR_CHILD_QUANTITY_TOO_LARGE =
+          join(ERROR, CHILD, QUANTITY, TOO_LARGE);
 }

--- a/src/main/java/org/openlmis/referencedata/validate/OrderableValidator.java
+++ b/src/main/java/org/openlmis/referencedata/validate/OrderableValidator.java
@@ -15,6 +15,7 @@
 
 package org.openlmis.referencedata.validate;
 
+import static org.openlmis.referencedata.util.messagekeys.OrderableMessageKeys.ERROR_CHILD_QUANTITY_TOO_LARGE;
 import static org.openlmis.referencedata.util.messagekeys.OrderableMessageKeys.ERROR_NET_CONTENT_REQUIRED;
 import static org.openlmis.referencedata.util.messagekeys.OrderableMessageKeys.ERROR_NULL;
 import static org.openlmis.referencedata.util.messagekeys.OrderableMessageKeys.ERROR_PACK_ROUNDING_THRESHOLD_REQUIRED;
@@ -90,6 +91,18 @@ public class OrderableValidator implements BaseValidator {
     validateTemperature(dto, errors);
     validateVolumeMeasurement(dto, errors);
     validateProductCode(dto, errors);
+    validateChildren(dto);
+  }
+
+  private void validateChildren(OrderableDto dto) {
+    if (dto.getChildren() == null) {
+      return;
+    }
+    dto.getChildren().forEach(child -> {
+      if (child.getQuantity() != null && child.getQuantity() > Integer.MAX_VALUE) {
+        throw new ValidationMessageException(ERROR_CHILD_QUANTITY_TOO_LARGE);
+      }
+    });
   }
 
   private void validatePrograms(OrderableDto dto) {

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -88,6 +88,7 @@ referenceData.error.orderable.notFound=Orderable not found
 referenceData.error.orderable.idMismatch=Orderable ID mismatch. The ID that was provided in the Orderable body differs from the one in url.
 referenceData.error.orderable.productCode.required=productCode is required
 referenceData.error.orderable.productCode.mustBeUnique=Product code is not unique
+referenceData.error.orderable.child.quantity.tooLarge=Kit constituent quantity exceeds the maximum allowed value.
 referenceData.error.orderable.packRoundingThreshold.required=packRoundingThreshold is required
 referenceData.error.orderable.roundToZero.required=roundToZero is required
 referenceData.error.orderable.netContent.required=netContent is required

--- a/src/test/java/org/openlmis/referencedata/validate/OrderableValidatorTest.java
+++ b/src/test/java/org/openlmis/referencedata/validate/OrderableValidatorTest.java
@@ -16,12 +16,14 @@
 package org.openlmis.referencedata.validate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.openlmis.referencedata.validate.OrderableValidator.IN_BOX_CUBE_DIMENSION;
 import static org.openlmis.referencedata.validate.OrderableValidator.MAXIMUM_TEMPERATURE;
 import static org.openlmis.referencedata.validate.OrderableValidator.MINIMUM_TEMPERATURE;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -34,6 +36,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.openlmis.referencedata.domain.Code;
 import org.openlmis.referencedata.domain.Orderable;
+import org.openlmis.referencedata.dto.ObjectReferenceDto;
+import org.openlmis.referencedata.dto.OrderableChildDto;
 import org.openlmis.referencedata.dto.OrderableDto;
 import org.openlmis.referencedata.dto.ProgramOrderableDto;
 import org.openlmis.referencedata.exception.ValidationMessageException;
@@ -253,5 +257,26 @@ public class OrderableValidatorTest {
     validator.validate(orderableDto, errors);
 
     assertThat(errors.getErrorCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldPassWhenChildQuantityIsWithinIntegerRange() {
+    OrderableChildDto child = new OrderableChildDto(
+        new ObjectReferenceDto(), (long) Integer.MAX_VALUE);
+    orderableDto.setChildren(new HashSet<>(Collections.singletonList(child)));
+
+    validator.validate(orderableDto, errors);
+
+    assertThat(errors.getErrorCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldRejectWhenChildQuantityExceedsIntegerMax() {
+    OrderableChildDto child = new OrderableChildDto(
+        new ObjectReferenceDto(), (long) Integer.MAX_VALUE + 1);
+    orderableDto.setChildren(new HashSet<>(Collections.singletonList(child)));
+
+    assertThatThrownBy(() -> validator.validate(orderableDto, errors))
+        .isInstanceOf(ValidationMessageException.class);
   }
 }

--- a/src/test/java/org/openlmis/referencedata/validate/OrderableValidatorTest.java
+++ b/src/test/java/org/openlmis/referencedata/validate/OrderableValidatorTest.java
@@ -85,7 +85,7 @@ public class OrderableValidatorTest {
   public void shouldNotFindErrorsWhenOrderableIsValid() {
     validator.validate(orderableDto, errors);
 
-    assertThat(errors.getErrorCount()).isEqualTo(0);
+    assertThat(errors.getErrorCount()).isZero();
   }
 
   @Test
@@ -193,7 +193,7 @@ public class OrderableValidatorTest {
 
     validator.validate(orderableDto, errors);
 
-    assertThat(errors.getErrorCount()).isEqualTo(0);
+    assertThat(errors.getErrorCount()).isZero();
   }
 
   @Test
@@ -235,7 +235,7 @@ public class OrderableValidatorTest {
 
     validator.validate(orderableDto, errors);
 
-    assertThat(errors.getErrorCount()).isEqualTo(0);
+    assertThat(errors.getErrorCount()).isZero();
   }
 
   @Test
@@ -267,7 +267,7 @@ public class OrderableValidatorTest {
 
     validator.validate(orderableDto, errors);
 
-    assertThat(errors.getErrorCount()).isEqualTo(0);
+    assertThat(errors.getErrorCount()).isZero();
   }
 
   @Test


### PR DESCRIPTION
Saving a kit constituent quantity larger than Integer.MAX_VALUE now returns 400.