### PR TITLE
OLMIS-8238: User preferences endpoint (packs/doses persistence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 15.6.0-SNAPSHOT (WIP)
 ==================
+* [OLMIS-8238](https://openlmis.atlassian.net/browse/OLMIS-8238): Add user preferences endpoint.
 
 15.5.0 / 2026-06-09
 ==================

--- a/src/integration-test/java/org/openlmis/referencedata/web/UserPreferenceControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/web/UserPreferenceControllerIntegrationTest.java
@@ -36,6 +36,7 @@ public class UserPreferenceControllerIntegrationTest extends BaseWebIntegrationT
   private static final String RESOURCE_URL = "/api/users/{userId}/preferences";
   private static final String QUANTITY_UNIT = "quantityUnit";
   private static final String PACKS = "PACKS";
+  private static final String USER_ID = "userId";
 
   @MockBean
   private UserPreferenceRepository userPreferenceRepository;
@@ -51,7 +52,7 @@ public class UserPreferenceControllerIntegrationTest extends BaseWebIntegrationT
     restAssured
         .given()
         .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
-        .pathParam("userId", userId)
+        .pathParam(USER_ID, userId)
         .when()
         .get(RESOURCE_URL)
         .then()
@@ -68,7 +69,7 @@ public class UserPreferenceControllerIntegrationTest extends BaseWebIntegrationT
     restAssured
         .given()
         .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
-        .pathParam("userId", userId)
+        .pathParam(USER_ID, userId)
         .when()
         .get(RESOURCE_URL)
         .then()
@@ -90,7 +91,7 @@ public class UserPreferenceControllerIntegrationTest extends BaseWebIntegrationT
         .given()
         .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .pathParam("userId", userId)
+        .pathParam(USER_ID, userId)
         .body(Collections.singletonMap(QUANTITY_UNIT, PACKS))
         .when()
         .put(RESOURCE_URL)
@@ -110,7 +111,7 @@ public class UserPreferenceControllerIntegrationTest extends BaseWebIntegrationT
         .given()
         .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .pathParam("userId", userId)
+        .pathParam(USER_ID, userId)
         .body(Collections.singletonMap("", PACKS))
         .when()
         .put(RESOURCE_URL)
@@ -129,7 +130,7 @@ public class UserPreferenceControllerIntegrationTest extends BaseWebIntegrationT
         .given()
         .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .pathParam("userId", userId)
+        .pathParam(USER_ID, userId)
         .body(Collections.singletonMap(QUANTITY_UNIT, PACKS))
         .when()
         .put(RESOURCE_URL)

--- a/src/integration-test/java/org/openlmis/referencedata/web/UserPreferenceControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/web/UserPreferenceControllerIntegrationTest.java
@@ -1,0 +1,141 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.referencedata.web;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import guru.nidi.ramltester.junit.RamlMatchers;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+import org.openlmis.referencedata.domain.RightName;
+import org.openlmis.referencedata.domain.UserPreference;
+import org.openlmis.referencedata.repository.UserPreferenceRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class UserPreferenceControllerIntegrationTest extends BaseWebIntegrationTest {
+
+  private static final String RESOURCE_URL = "/api/users/{userId}/preferences";
+  private static final String QUANTITY_UNIT = "quantityUnit";
+  private static final String PACKS = "PACKS";
+
+  @MockBean
+  private UserPreferenceRepository userPreferenceRepository;
+
+  private final UUID userId = UUID.randomUUID();
+
+  @Test
+  public void getShouldReturnUserPreferences() {
+    mockUserHasRight(RightName.USERS_MANAGE_RIGHT);
+    given(userPreferenceRepository.findAllByUserId(userId))
+        .willReturn(Collections.singletonList(new UserPreference(userId, QUANTITY_UNIT, PACKS)));
+
+    restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .pathParam("userId", userId)
+        .when()
+        .get(RESOURCE_URL)
+        .then()
+        .statusCode(200)
+        .body(QUANTITY_UNIT, is(PACKS));
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void getShouldReturnForbiddenForUnauthorizedToken() {
+    mockUserHasNoRight(RightName.USERS_MANAGE_RIGHT);
+
+    restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .pathParam("userId", userId)
+        .when()
+        .get(RESOURCE_URL)
+        .then()
+        .statusCode(403);
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void putShouldSaveUserPreferences() {
+    mockUserHasRight(RightName.USERS_MANAGE_RIGHT);
+    given(userRepository.existsById(userId)).willReturn(true);
+    given(userPreferenceRepository.findByUserIdAndPreferenceKey(userId, QUANTITY_UNIT))
+        .willReturn(Optional.empty());
+    given(userPreferenceRepository.findAllByUserId(userId))
+        .willReturn(Collections.singletonList(new UserPreference(userId, QUANTITY_UNIT, PACKS)));
+
+    restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .pathParam("userId", userId)
+        .body(Collections.singletonMap(QUANTITY_UNIT, PACKS))
+        .when()
+        .put(RESOURCE_URL)
+        .then()
+        .statusCode(200)
+        .body(QUANTITY_UNIT, is(PACKS));
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void putShouldReturnBadRequestForBlankPreferenceKey() {
+    mockUserHasRight(RightName.USERS_MANAGE_RIGHT);
+    given(userRepository.existsById(userId)).willReturn(true);
+
+    restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .pathParam("userId", userId)
+        .body(Collections.singletonMap("", PACKS))
+        .when()
+        .put(RESOURCE_URL)
+        .then()
+        .statusCode(400);
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void putShouldReturnNotFoundForMissingUser() {
+    mockUserHasRight(RightName.USERS_MANAGE_RIGHT);
+    given(userRepository.existsById(userId)).willReturn(false);
+
+    restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .pathParam("userId", userId)
+        .body(Collections.singletonMap(QUANTITY_UNIT, PACKS))
+        .when()
+        .put(RESOURCE_URL)
+        .then()
+        .statusCode(404);
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+}

--- a/src/integration-test/java/org/openlmis/referencedata/web/UserPreferenceControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/web/UserPreferenceControllerIntegrationTest.java
@@ -10,7 +10,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Affero General Public License for more details. You should have received a copy of
  * the GNU Affero General Public License along with this program. If not, see
- * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
  */
 
 package org.openlmis.referencedata.web;

--- a/src/main/java/org/openlmis/referencedata/domain/UserPreference.java
+++ b/src/main/java/org/openlmis/referencedata/domain/UserPreference.java
@@ -1,0 +1,70 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.referencedata.domain;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+import org.javers.core.metamodel.annotation.TypeName;
+
+/**
+ * A single per-user preference, stored as a generic key-value pair so that the reference data
+ * service stays agnostic of what the preference means (the semantics live in the UI). The unique
+ * (userId, preferenceKey) constraint guarantees one value per key per user.
+ */
+@Entity
+@Table(name = "user_preferences", schema = "referencedata",
+    uniqueConstraints = @UniqueConstraint(name = "user_preferences_userid_key_unique",
+        columnNames = {"userid", "preferencekey"}))
+@NoArgsConstructor
+@TypeName("UserPreference")
+public class UserPreference extends BaseEntity {
+
+  @Column(name = "userid", nullable = false)
+  @Type(type = UUID_TYPE)
+  @Getter
+  @Setter
+  private UUID userId;
+
+  @Column(name = "preferencekey", nullable = false, columnDefinition = "text")
+  @Getter
+  @Setter
+  private String preferenceKey;
+
+  @Column(name = "preferencevalue", nullable = false, columnDefinition = "text")
+  @Getter
+  @Setter
+  private String preferenceValue;
+
+  /**
+   * Creates a new preference for the given user.
+   *
+   * @param userId          the owner of the preference
+   * @param preferenceKey   the preference name
+   * @param preferenceValue the preference value
+   */
+  public UserPreference(UUID userId, String preferenceKey, String preferenceValue) {
+    this.userId = userId;
+    this.preferenceKey = preferenceKey;
+    this.preferenceValue = preferenceValue;
+  }
+}

--- a/src/main/java/org/openlmis/referencedata/repository/UserPreferenceRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/UserPreferenceRepository.java
@@ -1,0 +1,29 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.referencedata.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.openlmis.referencedata.domain.UserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, UUID> {
+
+  List<UserPreference> findAllByUserId(UUID userId);
+
+  Optional<UserPreference> findByUserIdAndPreferenceKey(UUID userId, String preferenceKey);
+}

--- a/src/main/java/org/openlmis/referencedata/util/messagekeys/UserPreferenceMessageKeys.java
+++ b/src/main/java/org/openlmis/referencedata/util/messagekeys/UserPreferenceMessageKeys.java
@@ -1,0 +1,26 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.referencedata.util.messagekeys;
+
+public abstract class UserPreferenceMessageKeys extends MessageKeys {
+  private static final String USER_PREFERENCE = "userPreference";
+  private static final String ERROR = join(SERVICE_ERROR, USER_PREFERENCE);
+  private static final String KEY = "key";
+  private static final String VALUE = "value";
+
+  public static final String ERROR_KEY_INVALID = join(ERROR, KEY, INVALID);
+  public static final String ERROR_VALUE_INVALID = join(ERROR, VALUE, INVALID);
+}

--- a/src/main/java/org/openlmis/referencedata/web/UserPreferenceController.java
+++ b/src/main/java/org/openlmis/referencedata/web/UserPreferenceController.java
@@ -1,0 +1,138 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.referencedata.web;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.openlmis.referencedata.domain.RightName;
+import org.openlmis.referencedata.domain.UserPreference;
+import org.openlmis.referencedata.exception.NotFoundException;
+import org.openlmis.referencedata.exception.ValidationMessageException;
+import org.openlmis.referencedata.repository.UserPreferenceRepository;
+import org.openlmis.referencedata.repository.UserRepository;
+import org.openlmis.referencedata.util.messagekeys.UserMessageKeys;
+import org.openlmis.referencedata.util.messagekeys.UserPreferenceMessageKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.profiler.Profiler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Controller
+@Transactional
+public class UserPreferenceController extends BaseController {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserPreferenceController.class);
+
+  private static final int MAX_LENGTH = 255;
+
+  @Autowired
+  private UserPreferenceRepository userPreferenceRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  /**
+   * Returns all of the given user's preferences as a key-value map. Accessible to the user
+   * themselves or to an administrator with the USERS_MANAGE right.
+   *
+   * @param userId the user whose preferences to return
+   * @return a map of preference key to value (empty when the user has none)
+   */
+  @GetMapping("/users/{userId}/preferences")
+  @ResponseStatus(HttpStatus.OK)
+  @ResponseBody
+  public Map<String, String> getUserPreferences(@PathVariable("userId") UUID userId) {
+    Profiler profiler = new Profiler("GET_USER_PREFERENCES");
+    profiler.setLogger(LOGGER);
+
+    checkAdminRight(RightName.USERS_MANAGE_RIGHT, true, userId, profiler);
+
+    profiler.start("FIND_PREFERENCES");
+    Map<String, String> preferences = userPreferenceRepository.findAllByUserId(userId)
+        .stream()
+        .collect(Collectors.toMap(
+            UserPreference::getPreferenceKey, UserPreference::getPreferenceValue));
+
+    profiler.stop().log();
+    return preferences;
+  }
+
+  /**
+   * Upserts the given preferences for the user (each provided key is created or updated, others are
+   * left untouched). Accessible to the user themselves or to an administrator with the USERS_MANAGE
+   * right.
+   *
+   * @param userId      the user whose preferences to update
+   * @param preferences the preference key-value pairs to store
+   * @return the user's full set of preferences after the update
+   */
+  @PutMapping("/users/{userId}/preferences")
+  @ResponseStatus(HttpStatus.OK)
+  @ResponseBody
+  public Map<String, String> saveUserPreferences(@PathVariable("userId") UUID userId,
+      @RequestBody Map<String, String> preferences) {
+    Profiler profiler = new Profiler("SAVE_USER_PREFERENCES");
+    profiler.setLogger(LOGGER);
+
+    checkAdminRight(RightName.USERS_MANAGE_RIGHT, true, userId, profiler);
+
+    profiler.start("CHECK_USER_EXISTS");
+    if (!userRepository.existsById(userId)) {
+      profiler.stop().log();
+      throw new NotFoundException(UserMessageKeys.ERROR_NOT_FOUND);
+    }
+
+    profiler.start("VALIDATE_AND_SAVE");
+    preferences.forEach((key, value) -> savePreference(userId, key, value));
+
+    profiler.start("FIND_PREFERENCES");
+    Map<String, String> result = userPreferenceRepository.findAllByUserId(userId)
+        .stream()
+        .collect(Collectors.toMap(
+            UserPreference::getPreferenceKey, UserPreference::getPreferenceValue));
+
+    profiler.stop().log();
+    return result;
+  }
+
+  private void savePreference(UUID userId, String key, String value) {
+    if (isBlank(key) || key.length() > MAX_LENGTH) {
+      throw new ValidationMessageException(UserPreferenceMessageKeys.ERROR_KEY_INVALID);
+    }
+    if (isBlank(value) || value.length() > MAX_LENGTH) {
+      throw new ValidationMessageException(UserPreferenceMessageKeys.ERROR_VALUE_INVALID);
+    }
+
+    UserPreference preference = userPreferenceRepository
+        .findByUserIdAndPreferenceKey(userId, key)
+        .orElseGet(() -> new UserPreference(userId, key, value));
+    preference.setPreferenceValue(value);
+
+    userPreferenceRepository.save(preference);
+  }
+}

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -32,6 +32,15 @@ schemas:
           }
       }
 
+  - userPreferences: |
+      {
+          "type": "object",
+          "$schema": "http://json-schema.org/draft-04/schema",
+          "title": "UserPreferences",
+          "description": "Map of user preference key to value",
+          "additionalProperties": { "type": "string" }
+      }
+
   - errorResponse: |
       {   "type": "object",
           "$schema": "http://json-schema.org/draft-03/schema",
@@ -1635,6 +1644,56 @@ resourceTypes:
                           body:
                             application/json:
                               schema: namedResourceArray
+                      "403":
+                          headers:
+                            Keep-Alive:
+                          body:
+                            application/json:
+                              schema: localizedErrorResponse
+                      "404":
+                          headers:
+                            Keep-Alive:
+                          body:
+                            application/json:
+                              schema: localizedErrorResponse
+          /preferences:
+              is: [ secured ]
+              displayName: User preferences
+              get:
+                  is: [ secured ]
+                  description: Returns the user's preferences as a key-value map. Accessible to the user themselves or an administrator with the USERS_MANAGE right.
+                  responses:
+                      "200":
+                          headers:
+                            Keep-Alive:
+                          body:
+                            application/json:
+                              schema: userPreferences
+                      "403":
+                          headers:
+                            Keep-Alive:
+                          body:
+                            application/json:
+                              schema: localizedErrorResponse
+              put:
+                  is: [ secured ]
+                  description: Creates or updates the user's preferences (key-value map). Accessible to the user themselves or an administrator with the USERS_MANAGE right.
+                  body:
+                      application/json:
+                          schema: userPreferences
+                  responses:
+                      "200":
+                          headers:
+                            Keep-Alive:
+                          body:
+                            application/json:
+                              schema: userPreferences
+                      "400":
+                          headers:
+                            Keep-Alive:
+                          body:
+                            application/json:
+                              schema: localizedErrorResponse
                       "403":
                           headers:
                             Keep-Alive:

--- a/src/main/resources/db/migration/20260615120000000__create_user_preferences_table.sql
+++ b/src/main/resources/db/migration/20260615120000000__create_user_preferences_table.sql
@@ -1,0 +1,20 @@
+-- WHEN COMMITTING OR REVIEWING THIS FILE: Make sure that the timestamp in the file name (that serves as a version) is the latest timestamp, and that no new migration have been added in the meanwhile.
+-- Adding migrations out of order may cause this migration to never execute or behave in an unexpected way.
+-- Migrations should NOT BE EDITED. Add a new migration to apply changes.
+
+CREATE TABLE user_preferences (
+    id uuid NOT NULL,
+    userid uuid NOT NULL,
+    preferencekey text NOT NULL,
+    preferencevalue text NOT NULL
+);
+
+ALTER TABLE ONLY user_preferences
+  ADD CONSTRAINT user_preferences_pkey PRIMARY KEY (id);
+
+ALTER TABLE user_preferences
+  ADD CONSTRAINT user_preferences_userid_fkey FOREIGN KEY (userid)
+  REFERENCES referencedata.users(id) ON DELETE CASCADE;
+
+ALTER TABLE user_preferences
+  ADD CONSTRAINT user_preferences_userid_key_unique UNIQUE (userid, preferencekey);

--- a/src/main/resources/db/migration/20260626092751954__create_user_preferences_table.sql
+++ b/src/main/resources/db/migration/20260626092751954__create_user_preferences_table.sql
@@ -1,7 +1,3 @@
--- WHEN COMMITTING OR REVIEWING THIS FILE: Make sure that the timestamp in the file name (that serves as a version) is the latest timestamp, and that no new migration have been added in the meanwhile.
--- Adding migrations out of order may cause this migration to never execute or behave in an unexpected way.
--- Migrations should NOT BE EDITED. Add a new migration to apply changes.
-
 CREATE TABLE user_preferences (
     id uuid NOT NULL,
     userid uuid NOT NULL,

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -306,6 +306,8 @@ referenceData.error.user.import.role.required.forAllEntries=Role is required for
 referenceData.error.user.import.role.invalidRoleType=Invalid role type for users: {0}
 referenceData.error.user.import.role.missingProgramForSupervisionRole=Program code is required for supervision roles. Missing for users: {0}
 referenceData.error.user.import.role.missingWarehouseForFulfillmentRole=Warehouse code is required for fulfillment roles. Missing for users: {0}
+referenceData.error.userPreference.key.invalid=The preference key is required and must not exceed 255 characters.
+referenceData.error.userPreference.value.invalid=The preference value is required and must not exceed 255 characters.
 
 # Search params
 referenceData.error.invalid.format.uuid=UUID {0} parameter has wrong format for field {1}.

--- a/src/test/java/org/openlmis/referencedata/web/UserPreferenceControllerTest.java
+++ b/src/test/java/org/openlmis/referencedata/web/UserPreferenceControllerTest.java
@@ -1,0 +1,193 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.referencedata.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openlmis.referencedata.domain.RightName;
+import org.openlmis.referencedata.domain.UserPreference;
+import org.openlmis.referencedata.exception.NotFoundException;
+import org.openlmis.referencedata.exception.ValidationMessageException;
+import org.openlmis.referencedata.repository.UserPreferenceRepository;
+import org.openlmis.referencedata.repository.UserRepository;
+import org.openlmis.referencedata.service.RightService;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("PMD.TooManyMethods")
+public class UserPreferenceControllerTest {
+
+  private static final String QUANTITY_UNIT_KEY = "quantityUnit";
+  private static final String PACKS = "PACKS";
+  private static final String DOSES = "DOSES";
+
+  @InjectMocks
+  private UserPreferenceController controller;
+
+  @Mock
+  private UserPreferenceRepository userPreferenceRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private RightService rightService;
+
+  private final UUID userId = UUID.randomUUID();
+
+  @Test
+  public void shouldReturnUserPreferencesAsMap() {
+    when(userPreferenceRepository.findAllByUserId(userId)).thenReturn(Arrays.asList(
+        new UserPreference(userId, QUANTITY_UNIT_KEY, PACKS),
+        new UserPreference(userId, "locale", "en")));
+
+    Map<String, String> result = controller.getUserPreferences(userId);
+
+    assertEquals(PACKS, result.get(QUANTITY_UNIT_KEY));
+    assertEquals("en", result.get("locale"));
+    verify(rightService).checkAdminRight(RightName.USERS_MANAGE_RIGHT, true, userId);
+  }
+
+  @Test
+  public void shouldReturnEmptyMapWhenUserHasNoPreferences() {
+    when(userPreferenceRepository.findAllByUserId(userId)).thenReturn(Collections.emptyList());
+
+    assertTrue(controller.getUserPreferences(userId).isEmpty());
+  }
+
+  @Test
+  public void shouldCreateNewPreferenceOnPut() {
+    when(userRepository.existsById(userId)).thenReturn(true);
+    when(userPreferenceRepository.findByUserIdAndPreferenceKey(userId, QUANTITY_UNIT_KEY))
+        .thenReturn(Optional.empty());
+    when(userPreferenceRepository.findAllByUserId(userId)).thenReturn(
+        Collections.singletonList(new UserPreference(userId, QUANTITY_UNIT_KEY, PACKS)));
+
+    Map<String, String> result = controller.saveUserPreferences(userId,
+        Collections.singletonMap(QUANTITY_UNIT_KEY, PACKS));
+
+    assertEquals(PACKS, result.get(QUANTITY_UNIT_KEY));
+    verify(rightService).checkAdminRight(RightName.USERS_MANAGE_RIGHT, true, userId);
+
+    ArgumentCaptor<UserPreference> captor = ArgumentCaptor.forClass(UserPreference.class);
+    verify(userPreferenceRepository).save(captor.capture());
+    assertEquals(QUANTITY_UNIT_KEY, captor.getValue().getPreferenceKey());
+    assertEquals(PACKS, captor.getValue().getPreferenceValue());
+  }
+
+  @Test
+  public void shouldUpdateExistingPreferenceOnPut() {
+    UserPreference existing = new UserPreference(userId, QUANTITY_UNIT_KEY, DOSES);
+    when(userRepository.existsById(userId)).thenReturn(true);
+    when(userPreferenceRepository.findByUserIdAndPreferenceKey(userId, QUANTITY_UNIT_KEY))
+        .thenReturn(Optional.of(existing));
+    when(userPreferenceRepository.findAllByUserId(userId))
+        .thenReturn(Collections.singletonList(existing));
+
+    controller.saveUserPreferences(userId, Collections.singletonMap(QUANTITY_UNIT_KEY, PACKS));
+
+    assertEquals(PACKS, existing.getPreferenceValue());
+    verify(userPreferenceRepository).save(existing);
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void shouldThrowNotFoundWhenUserDoesNotExistOnPut() {
+    when(userRepository.existsById(userId)).thenReturn(false);
+
+    controller.saveUserPreferences(userId, Collections.singletonMap(QUANTITY_UNIT_KEY, PACKS));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldRejectBlankValueOnPut() {
+    when(userRepository.existsById(userId)).thenReturn(true);
+
+    controller.saveUserPreferences(userId, Collections.singletonMap(QUANTITY_UNIT_KEY, ""));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldRejectBlankKeyOnPut() {
+    when(userRepository.existsById(userId)).thenReturn(true);
+
+    controller.saveUserPreferences(userId, Collections.singletonMap("", PACKS));
+  }
+
+  @Test
+  public void shouldUpsertEachProvidedKeyOnPut() {
+    when(userRepository.existsById(userId)).thenReturn(true);
+    when(userPreferenceRepository.findByUserIdAndPreferenceKey(any(UUID.class), any(String.class)))
+        .thenReturn(Optional.empty());
+    when(userPreferenceRepository.findAllByUserId(userId)).thenReturn(Collections.emptyList());
+
+    Map<String, String> body = new HashMap<>();
+    body.put(QUANTITY_UNIT_KEY, PACKS);
+    body.put("locale", "fr");
+
+    controller.saveUserPreferences(userId, body);
+
+    verify(userPreferenceRepository, times(2)).save(any(UserPreference.class));
+  }
+
+  @Test
+  public void shouldAcceptKeyAndValueAtMaxLength() {
+    String maxLength = stringOfLength(255);
+    when(userRepository.existsById(userId)).thenReturn(true);
+    when(userPreferenceRepository.findByUserIdAndPreferenceKey(userId, maxLength))
+        .thenReturn(Optional.empty());
+    when(userPreferenceRepository.findAllByUserId(userId)).thenReturn(Collections.emptyList());
+
+    controller.saveUserPreferences(userId, Collections.singletonMap(maxLength, maxLength));
+
+    verify(userPreferenceRepository).save(any(UserPreference.class));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldRejectKeyExceedingMaxLength() {
+    when(userRepository.existsById(userId)).thenReturn(true);
+
+    controller.saveUserPreferences(
+        userId, Collections.singletonMap(stringOfLength(256), PACKS));
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldRejectValueExceedingMaxLength() {
+    when(userRepository.existsById(userId)).thenReturn(true);
+
+    controller.saveUserPreferences(
+        userId, Collections.singletonMap(QUANTITY_UNIT_KEY, stringOfLength(256)));
+  }
+
+  private static String stringOfLength(int length) {
+    char[] chars = new char[length];
+    Arrays.fill(chars, 'x');
+    return new String(chars);
+  }
+}


### PR DESCRIPTION
Part of OLMIS-8238 (facility-level packs/doses display).

Adds `/api/users/{userId}/preferences` — a per-user key-value preference store. Used to persist the user's packs/doses unit selection server-side so it survives logout (which clears local storage) and is restored on next login.

https://openlmis.atlassian.net/browse/OLMIS-8238