### PR TITLE
[MW-1477] Lockout QA changes

### DIFF
--- a/src/main/java/org/openlmis/referencedata/dto/UserDto.java
+++ b/src/main/java/org/openlmis/referencedata/dto/UserDto.java
@@ -17,6 +17,7 @@ package org.openlmis.referencedata.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.Sets;
+import java.time.ZonedDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -64,13 +65,16 @@ public final class UserDto extends UserContactDetailsDto implements User.Exporte
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Boolean lockedOut;
 
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private ZonedDateTime lastUnsuccessfulAuthenticationAttemptDate;
+
   private Map<String, Object> extraData;
 
   private Set<RoleAssignmentDto> roleAssignments = Sets.newHashSet();
 
   public UserAuthDetailsApiContract toUserAuthDetailsApiContract(String defaultPassword) {
     return new UserAuthDetailsApiContract(this.getId(), this.getUsername(),
-        defaultPassword, this.isActive(), null);
+        defaultPassword, this.isActive(), null, null);
   }
 
   /**
@@ -108,5 +112,6 @@ public final class UserDto extends UserContactDetailsDto implements User.Exporte
     private String password;
     private Boolean enabled;
     private Boolean lockedOut;
+    private ZonedDateTime lastUnsuccessfulAuthenticationAttemptDate;
   }
 }

--- a/src/main/java/org/openlmis/referencedata/service/UserService.java
+++ b/src/main/java/org/openlmis/referencedata/service/UserService.java
@@ -118,36 +118,38 @@ public class UserService implements ExportableDataService<UserDto> {
 
   /**
    * Narrows the search params' id filter (in place) to the auth users matching the requested
-   * lockout state, so pagination stays correct. Returns their id-to-lockout-state map for response
-   * enrichment, or {@code null} when no lockout filtering is requested.
+   * lockout state, so pagination stays correct. Returns their id-to-auth-details map (lockout
+   * state and last unsuccessful login date) for response enrichment, or {@code null} when no
+   * lockout filtering is requested.
    *
    * @param searchParams the user search params
-   * @return the lockout-state map, or {@code null} when no lockout filtering is requested
+   * @return the id-to-auth-details map, or {@code null} when no lockout filtering is requested
    */
-  public Map<UUID, Boolean> applyLockoutFilter(UserSearchParams searchParams) {
+  public Map<UUID, UserDto.UserAuthDetailsApiContract> applyLockoutFilter(
+      UserSearchParams searchParams) {
     if (searchParams.getLockedOut() == null) {
       return null;
     }
 
-    Map<UUID, Boolean> lockoutStateById = userAuthService
+    Map<UUID, UserDto.UserAuthDetailsApiContract> authDetailsById = userAuthService
         .getAuthUserDetails(searchParams.getLockedOut())
         .stream()
         .collect(Collectors.toMap(
             UserDto.UserAuthDetailsApiContract::getId,
-            UserDto.UserAuthDetailsApiContract::getLockedOut));
+            contract -> contract));
 
-    Set<String> ids = lockoutStateById.keySet().stream()
+    Set<String> ids = authDetailsById.keySet().stream()
         .map(UUID::toString)
         .collect(Collectors.toSet());
 
     if (!CollectionUtils.isEmpty(searchParams.getId())) {
       ids.retainAll(searchParams.getId());
-      lockoutStateById.keySet().removeIf(id -> !ids.contains(id.toString()));
+      authDetailsById.keySet().removeIf(id -> !ids.contains(id.toString()));
     }
 
     searchParams.setId(ids);
 
-    return lockoutStateById;
+    return authDetailsById;
   }
 
   /**

--- a/src/main/java/org/openlmis/referencedata/web/UserController.java
+++ b/src/main/java/org/openlmis/referencedata/web/UserController.java
@@ -259,11 +259,11 @@ public class UserController extends BaseController {
     LOGGER.debug("Getting all users");
 
     boolean filterByLockout = requestParams.getLockedOut() != null;
-    Map<UUID, Boolean> lockoutStateById = null;
+    Map<UUID, UserDto.UserAuthDetailsApiContract> authDetailsById = null;
 
     if (filterByLockout) {
       profiler.start("APPLY_LOCKOUT_FILTER");
-      lockoutStateById = userService.applyLockoutFilter(requestParams);
+      authDetailsById = userService.applyLockoutFilter(requestParams);
 
       if (requestParams.getId().isEmpty()) {
         profiler.stop().log();
@@ -280,7 +280,12 @@ public class UserController extends BaseController {
     if (filterByLockout) {
       profiler.start("ENRICH_WITH_LOCKOUT_STATE");
       for (UserDto userDto : userDtos.getContent()) {
-        userDto.setLockedOut(lockoutStateById.get(userDto.getId()));
+        UserDto.UserAuthDetailsApiContract details = authDetailsById.get(userDto.getId());
+        if (details != null) {
+          userDto.setLockedOut(details.getLockedOut());
+          userDto.setLastUnsuccessfulAuthenticationAttemptDate(
+              details.getLastUnsuccessfulAuthenticationAttemptDate());
+        }
       }
     }
 

--- a/src/test/java/org/openlmis/referencedata/service/UserServiceTest.java
+++ b/src/test/java/org/openlmis/referencedata/service/UserServiceTest.java
@@ -429,7 +429,8 @@ public class UserServiceTest {
     Map<UUID, UserDto.UserAuthDetailsApiContract> result = userService.applyLockoutFilter(params);
 
     assertEquals(Boolean.TRUE, result.get(lockedUserId).getLockedOut());
-    assertEquals(attemptDate, result.get(lockedUserId).getLastUnsuccessfulAuthenticationAttemptDate());
+    assertEquals(attemptDate,
+        result.get(lockedUserId).getLastUnsuccessfulAuthenticationAttemptDate());
     assertEquals(Collections.singleton(lockedUserId.toString()), params.getId());
     verify(userAuthService).getAuthUserDetails(true);
   }

--- a/src/test/java/org/openlmis/referencedata/service/UserServiceTest.java
+++ b/src/test/java/org/openlmis/referencedata/service/UserServiceTest.java
@@ -29,6 +29,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -404,7 +405,7 @@ public class UserServiceTest {
   public void applyLockoutFilterShouldReturnNullWhenLockedOutNotRequested() {
     UserSearchParams params = new UserSearchParamsDataBuilder().withLockedOut(null).build();
 
-    Map<UUID, Boolean> result = userService.applyLockoutFilter(params);
+    Map<UUID, UserDto.UserAuthDetailsApiContract> result = userService.applyLockoutFilter(params);
 
     assertNull(result);
     verifyNoInteractions(userAuthService);
@@ -413,8 +414,9 @@ public class UserServiceTest {
   @Test
   public void applyLockoutFilterShouldSetIdsFromAuthService() {
     UUID lockedUserId = UUID.randomUUID();
+    ZonedDateTime attemptDate = ZonedDateTime.now();
     UserDto.UserAuthDetailsApiContract authDetails =
-        new UserDto.UserAuthDetailsApiContract(lockedUserId, "john", null, true, true);
+        new UserDto.UserAuthDetailsApiContract(lockedUserId, "john", null, true, true, attemptDate);
 
     when(userAuthService.getAuthUserDetails(true))
         .thenReturn(Collections.singletonList(authDetails));
@@ -424,9 +426,10 @@ public class UserServiceTest {
         .withLockedOut(true)
         .build();
 
-    Map<UUID, Boolean> result = userService.applyLockoutFilter(params);
+    Map<UUID, UserDto.UserAuthDetailsApiContract> result = userService.applyLockoutFilter(params);
 
-    assertEquals(Boolean.TRUE, result.get(lockedUserId));
+    assertEquals(Boolean.TRUE, result.get(lockedUserId).getLockedOut());
+    assertEquals(attemptDate, result.get(lockedUserId).getLastUnsuccessfulAuthenticationAttemptDate());
     assertEquals(Collections.singleton(lockedUserId.toString()), params.getId());
     verify(userAuthService).getAuthUserDetails(true);
   }
@@ -437,15 +440,15 @@ public class UserServiceTest {
     UUID lockedUserTwo = UUID.randomUUID();
 
     when(userAuthService.getAuthUserDetails(true)).thenReturn(Arrays.asList(
-        new UserDto.UserAuthDetailsApiContract(lockedUserOne, "one", null, true, true),
-        new UserDto.UserAuthDetailsApiContract(lockedUserTwo, "two", null, true, true)));
+        new UserDto.UserAuthDetailsApiContract(lockedUserOne, "one", null, true, true, null),
+        new UserDto.UserAuthDetailsApiContract(lockedUserTwo, "two", null, true, true, null)));
 
     UserSearchParams params = new UserSearchParamsDataBuilder()
         .withId(newHashSet(lockedUserOne.toString()))
         .withLockedOut(true)
         .build();
 
-    Map<UUID, Boolean> result = userService.applyLockoutFilter(params);
+    Map<UUID, UserDto.UserAuthDetailsApiContract> result = userService.applyLockoutFilter(params);
 
     assertEquals(Collections.singleton(lockedUserOne.toString()), params.getId());
     assertEquals(1, result.size());

--- a/src/test/java/org/openlmis/referencedata/web/UserControllerTest.java
+++ b/src/test/java/org/openlmis/referencedata/web/UserControllerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.common.collect.Sets;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -239,8 +240,12 @@ public class UserControllerTest {
         .withId(Sets.newHashSet(user1.getId().toString()))
         .withLockedOut(true)
         .build();
-    Map<UUID, Boolean> lockoutState = Collections.singletonMap(user1.getId(), true);
-    when(userService.applyLockoutFilter(searchParams)).thenReturn(lockoutState);
+    ZonedDateTime attemptDate = ZonedDateTime.now();
+    UserDto.UserAuthDetailsApiContract details = new UserDto.UserAuthDetailsApiContract(
+        user1.getId(), user1.getUsername(), null, true, true, attemptDate);
+    Map<UUID, UserDto.UserAuthDetailsApiContract> authDetails =
+        Collections.singletonMap(user1.getId(), details);
+    when(userService.applyLockoutFilter(searchParams)).thenReturn(authDetails);
     when(userService.searchUsersById(searchParams, pageable))
         .thenReturn(Pagination.getPage(Lists.newArrayList(user1), PageRequest.of(0, 1)));
 
@@ -250,6 +255,8 @@ public class UserControllerTest {
     //then
     assertThat(userDtos.getContent()).hasSize(1);
     assertThat(userDtos.getContent().get(0).getLockedOut()).isTrue();
+    assertThat(userDtos.getContent().get(0).getLastUnsuccessfulAuthenticationAttemptDate())
+        .isEqualTo(attemptDate);
   }
 
   @Test


### PR DESCRIPTION
Task:
https://openlmis.atlassian.net/browse/MW-1477
Description:
Add `lastUnsuccessfulAuthenticationAttemptDate` to `UserDto` for use in the Lockouts tab.