### PR TITLE
OLMIS-8280: Fix potential NullPointerException in CommodityTypeController

### DIFF
--- a/src/main/java/org/openlmis/referencedata/web/CommodityTypeController.java
+++ b/src/main/java/org/openlmis/referencedata/web/CommodityTypeController.java
@@ -18,6 +18,7 @@ package org.openlmis.referencedata.web;
 import static org.openlmis.referencedata.domain.RightName.ORDERABLES_MANAGE;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import org.openlmis.referencedata.domain.CommodityType;
@@ -77,7 +78,9 @@ public class CommodityTypeController extends BaseController {
     validator.validate(commodityTypeDto, bindingResult);
     throwValidationMessageExceptionIfErrors(bindingResult);
 
-    CommodityType commodityType = CommodityType.newInstance(commodityTypeDto);
+    CommodityType commodityType = Objects.requireNonNull(
+        CommodityType.newInstance(commodityTypeDto),
+        "commodityType must not be null for a validated commodityTypeDto");
 
     if (null != commodityType.getId()) {
       UUID productId = commodityType.getId();


### PR DESCRIPTION
## Problem

The SonarCloud Quality Gate for `master` fails on a single condition — **Reliability Rating: C on New Code** (required A).

The culprit is a Blocker reliability bug (`javabugs:S2259`) in `CommodityTypeController.createOrUpdate`:

- `CommodityType.newInstance(Importer)` returns `null` when its argument is `null`.
- The controller dereferenced the result immediately — `commodityType.getId()` — without a null check, so SonarCloud reports a possible `NullPointerException`.

The rule was surfaced by the Java 21 analyzer migration (OLMIS-8280); the affected line is pre-existing but newly detected, which places it in the New Code window.

## Fix

`commodityTypeDto` is a validated `@RequestBody` and is never `null` at this call site, so `newInstance` never actually returns `null` here. The result is now wrapped in `Objects.requireNonNull`:

```java
CommodityType commodityType = Objects.requireNonNull(
    CommodityType.newInstance(commodityTypeDto),
    "commodityType must not be null for a validated commodityTypeDto");
```

This:
- makes the non-null invariant explicit at the call site and clears `javabugs:S2259`;
- avoids an unreachable `if (... == null) throw` branch, so **Coverage on New Lines is unaffected**.

`CommodityType.newInstance()` is intentionally left unchanged — its `null` return is required for the recursive parent assignment (`newInstance(importer.getParent())`), where a top-level commodity type legitimately has no parent.

## Impact

No functional change: the guarded path was already unreachable for valid requests. Restores the Reliability Rating on New Code to A so the Quality Gate passes.
