### PR TITLE
MW-1471: Activate Prometheus metrics endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-web"
     compile "org.springframework.boot:spring-boot-starter-data-jpa"
     compile "org.springframework.boot:spring-boot-starter-actuator"
+    compile "io.micrometer:micrometer-registry-prometheus"
     compile 'org.springframework.boot:spring-boot-starter-data-redis'
     compile 'org.javers:javers-spring-boot-starter-sql:2.8.1'
     compile "org.projectlombok:lombok"

--- a/src/main/java/org/openlmis/referencedata/security/ResourceServerSecurityConfiguration.java
+++ b/src/main/java/org/openlmis/referencedata/security/ResourceServerSecurityConfiguration.java
@@ -91,6 +91,7 @@ public class ResourceServerSecurityConfiguration implements ResourceServerConfig
             "/webjars/**",
             "/referencedata/webjars/**",
             "/actuator/health",
+            "/actuator/prometheus",
             "/referencedata/docs/**",
             "/localeSettings",
             "/togglz-console/**",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,7 +35,8 @@ spring.jpa.properties.hibernate.order_updates=true
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true
 management.endpoint.togglz.enabled=true
-management.endpoints.web.exposure.include=health,togglz
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=health,togglz,prometheus
 
 server.compression.enabled=true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css


### PR DESCRIPTION
Activates the Prometheus (Micrometer) actuator endpoint so JVM/HTTP metrics can be scraped by a Grafana Alloy agent (OpenLMIS Malawi monitoring).

Changes:
- build.gradle: add io.micrometer:micrometer-registry-prometheus (actuator starter already present).
- application.properties: enable+expose the prometheus endpoint (management.endpoint.prometheus.enabled=true; appended prometheus to management.endpoints.web.exposure.include; master sets enabled-by-default=false).
- ResourceServerSecurityConfiguration: permit /actuator/prometheus (alongside the existing /actuator/health).

Security: served on the app port, permitted like /actuator/health; only reachable on the internal network in the Malawi deployment (services not host-published, nginx routes /api/* only).

Verified: builds, boots, GET /actuator/prometheus returns 200 with JVM/HTTP metrics. Companion hotfix branch rel-15.3.0-hotfix.1 carries the same activation on the deployed 15.3.0-hotfix line.