### PR TITLE
[OLMIS-8287] GTIN normalization & lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 * [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Removed the axios dependency from the Consul registration script, replacing it with the native Node `http` client (no more axios security advisories to track).
 * GET `/tradeItems` now supports a repeatable `id` query parameter to filter trade items by their identifiers.
 * [OLMIS-8118](https://openlmis.atlassian.net/browse/OLMIS-8118): Reject kit child quantity exceeding Integer max.
+* [OLMIS-8287](https://openlmis.atlassian.net/browse/OLMIS-8287): GET `/tradeItems` now supports a `gtin` query parameter; GTINs are normalized to 14 digits and validated (length, GS1 check digit) on write.
 
 15.5.0 / 2026-06-09
 ==================

--- a/src/integration-test/java/org/openlmis/referencedata/repository/TradeItemRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/repository/TradeItemRepositoryIntegrationTest.java
@@ -20,9 +20,15 @@ import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.iterableWithSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Optional;
 import java.util.UUID;
+import javax.persistence.EntityManager;
 import org.junit.Test;
 import org.openlmis.referencedata.domain.Gtin;
 import org.openlmis.referencedata.domain.TradeItem;
@@ -34,12 +40,21 @@ import org.springframework.data.repository.CrudRepository;
 public class TradeItemRepositoryIntegrationTest extends
     BaseCrudRepositoryIntegrationTest<TradeItem> {
 
+  private static final String GTIN_8 = "96385074";
+  private static final String GTIN_13 = "5901234123457";
+  private static final String PADDED_GTIN_13 = "05901234123457";
+  private static final String GTIN_14 = "05890123456786";
+  private static final String LEGACY_GTIN = "123456789";
+
   private TradeItem tradeItem1;
   private TradeItem tradeItem2;
   private TradeItem tradeItem3;
 
   @Autowired
   private TradeItemRepository repository;
+
+  @Autowired
+  private EntityManager entityManager;
 
   @Override
   CrudRepository<TradeItem, UUID> getRepository() {
@@ -108,15 +123,81 @@ public class TradeItemRepositoryIntegrationTest extends
   @Test(expected = DataIntegrityViolationException.class)
   public void shouldNotAllowDuplicateGtin() {
     TradeItem tradeItem = generateInstance();
-    tradeItem.setGtin(new Gtin("12345678"));
+    tradeItem.setGtin(new Gtin(GTIN_8));
 
     TradeItem anotherTradeItem = generateInstance();
-    anotherTradeItem.setGtin(new Gtin("12345678"));
+    anotherTradeItem.setGtin(new Gtin(GTIN_8));
 
     repository.save(tradeItem);
     repository.save(anotherTradeItem);
 
     repository.flush();
+  }
+
+  @Test(expected = DataIntegrityViolationException.class)
+  public void shouldNotAllowGtinDuplicatedByNormalization() {
+    TradeItem tradeItem = generateInstance();
+    tradeItem.setGtin(new Gtin(GTIN_13));
+
+    TradeItem anotherTradeItem = generateInstance();
+    anotherTradeItem.setGtin(new Gtin(PADDED_GTIN_13));
+
+    repository.save(tradeItem);
+    repository.save(anotherTradeItem);
+
+    repository.flush();
+  }
+
+  @Test
+  public void shouldFindByGtin() {
+    TradeItem tradeItem = generateInstance();
+    tradeItem.setGtin(new Gtin(GTIN_14));
+    repository.saveAndFlush(tradeItem);
+
+    Optional<TradeItem> result = repository.findByGtin(GTIN_14);
+
+    assertTrue(result.isPresent());
+    assertEquals(tradeItem, result.get());
+  }
+
+  @Test
+  public void shouldFindByGtinStoredInShorterStructure() {
+    TradeItem tradeItem = generateInstance();
+    tradeItem.setGtin(new Gtin(GTIN_13));
+    repository.saveAndFlush(tradeItem);
+
+    Optional<TradeItem> result = repository.findByGtin(PADDED_GTIN_13);
+
+    assertTrue(result.isPresent());
+    assertEquals(tradeItem, result.get());
+  }
+
+  @Test
+  public void shouldReadTradeItemWithGtinViolatingCurrentValidationRules() {
+    // rows from earlier versions are not migrated, so reading a now-invalid GTIN must still work
+    TradeItem tradeItem = generateInstance();
+    repository.saveAndFlush(tradeItem);
+
+    entityManager
+        .createNativeQuery("UPDATE referencedata.trade_items SET gtin = ?1 WHERE id = ?2")
+        .setParameter(1, LEGACY_GTIN)
+        .setParameter(2, tradeItem.getId())
+        .executeUpdate();
+    entityManager.clear();
+
+    TradeItem result = repository.findById(tradeItem.getId()).orElse(null);
+
+    assertNotNull(result);
+    assertEquals(LEGACY_GTIN, result.getGtin().getGtin());
+  }
+
+  @Test
+  public void shouldNotFindByUnknownGtin() {
+    TradeItem tradeItem = generateInstance();
+    tradeItem.setGtin(new Gtin(GTIN_14));
+    repository.saveAndFlush(tradeItem);
+
+    assertFalse(repository.findByGtin(PADDED_GTIN_13).isPresent());
   }
 
   private void setUpTradeItemsWithClassifications() {

--- a/src/integration-test/java/org/openlmis/referencedata/web/TradeItemControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/web/TradeItemControllerIntegrationTest.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.openlmis.referencedata.domain.RightName.ORDERABLES_MANAGE;
 import static org.openlmis.referencedata.dto.TradeItemDto.newInstance;
+import static org.openlmis.referencedata.util.messagekeys.TradeItemMessageKeys.ERROR_GTIN_INVALID_CHECK_DIGIT;
+import static org.openlmis.referencedata.util.messagekeys.TradeItemMessageKeys.ERROR_GTIN_INVALID_LENGTH;
 import static org.openlmis.referencedata.util.messagekeys.TradeItemMessageKeys.ERROR_MANUFACTURER_REQUIRED;
 
 import guru.nidi.ramltester.junit.RamlMatchers;
@@ -55,9 +57,12 @@ public class TradeItemControllerIntegrationTest extends BaseWebIntegrationTest {
   private static final String RESOURCE_URL = "/api/tradeItems";
   private static final String CID = "cid";
   private static final String MANUFACTURER_ONE_NAME = "one";
-  private static final String GTIN_ONE = "11111111";
+  private static final String GTIN_ONE = "96385074";
   private static final String MANUFACTURER_TWO_NAME = "two";
-  private static final String GTIN_TWO = "22222222";
+  private static final String GTIN_TWO = "22222220";
+  private static final String GTIN_13 = "5901234123457";
+  private static final String PADDED_GTIN_13 = "05901234123457";
+  private static final String GTIN_14 = "05890123456786";
 
   @Before
   public void setUp() {
@@ -68,7 +73,7 @@ public class TradeItemControllerIntegrationTest extends BaseWebIntegrationTest {
   public void shouldCreateNewTradeItem() {
     mockUserHasRight(ORDERABLES_MANAGE);
 
-    TradeItem tradeItem = generateItem("item", "12345678");
+    TradeItem tradeItem = generateItem("item", GTIN_14);
 
     when(tradeItemRepository.save(any(TradeItem.class))).thenAnswer(new SaveAnswer<TradeItem>());
 
@@ -192,6 +197,127 @@ public class TradeItemControllerIntegrationTest extends BaseWebIntegrationTest {
 
     List<TradeItemDto> expected = newInstance(items);
     checkIfEquals(response, expected);
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void shouldRetrieveTradeItemByGtin() {
+    TradeItem item = generateItem(MANUFACTURER_ONE_NAME, GTIN_14);
+
+    when(tradeItemRepository.findByGtin(GTIN_14)).thenReturn(Optional.of(item));
+
+    PageDto response = restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .queryParam("gtin", GTIN_14)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(RESOURCE_URL)
+        .then()
+        .statusCode(200)
+        .extract().as(PageDto.class);
+
+    checkIfEquals(response, newInstance(Collections.singletonList(item)));
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void shouldRetrieveTradeItemByGtinInShorterStructure() {
+    TradeItem item = generateItem(MANUFACTURER_ONE_NAME, GTIN_13);
+
+    when(tradeItemRepository.findByGtin(PADDED_GTIN_13)).thenReturn(Optional.of(item));
+
+    PageDto response = restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .queryParam("gtin", GTIN_13)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(RESOURCE_URL)
+        .then()
+        .statusCode(200)
+        .extract().as(PageDto.class);
+
+    checkIfEquals(response, newInstance(Collections.singletonList(item)));
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void shouldReturnEmptyPageIfGtinIsNotRegistered() {
+    when(tradeItemRepository.findByGtin(GTIN_14)).thenReturn(Optional.empty());
+
+    PageDto response = restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .queryParam("gtin", GTIN_14)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(RESOURCE_URL)
+        .then()
+        .statusCode(200)
+        .extract().as(PageDto.class);
+
+    checkIfEquals(response, Collections.emptyList());
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void getByGtinShouldReturnUnauthorizedWithoutAuthorization() {
+
+    restAssured
+        .given()
+        .queryParam("gtin", GTIN_14)
+        .when()
+        .get(RESOURCE_URL)
+        .then()
+        .statusCode(401);
+
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void shouldRejectCreateIfGtinHasInvalidCheckDigit() {
+    mockUserHasRight(ORDERABLES_MANAGE);
+
+    TradeItemDto object = newInstance(generateItem(MANUFACTURER_ONE_NAME, GTIN_14));
+    object.setGtin("05890123456787");
+
+    checkBadRequestBody(object, ERROR_GTIN_INVALID_CHECK_DIGIT, RESOURCE_URL);
+  }
+
+  @Test
+  public void shouldRejectCreateIfGtinHasInvalidLength() {
+    mockUserHasRight(ORDERABLES_MANAGE);
+
+    TradeItemDto object = newInstance(generateItem(MANUFACTURER_ONE_NAME, GTIN_14));
+    object.setGtin("963850740");
+
+    checkBadRequestBody(object, ERROR_GTIN_INVALID_LENGTH, RESOURCE_URL);
+  }
+
+  @Test
+  public void shouldStoreGtinPaddedToFourteenDigits() {
+    mockUserHasRight(ORDERABLES_MANAGE);
+
+    TradeItemDto object = newInstance(generateItem(MANUFACTURER_ONE_NAME, GTIN_14));
+    object.setGtin(GTIN_13);
+
+    TradeItemDto response = restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(object)
+        .when()
+        .put(RESOURCE_URL)
+        .then()
+        .statusCode(200)
+        .extract().as(TradeItemDto.class);
+
+    assertEquals(PADDED_GTIN_13, response.getGtin());
 
     assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
   }

--- a/src/integration-test/java/org/openlmis/referencedata/web/TradeItemControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/web/TradeItemControllerIntegrationTest.java
@@ -52,10 +52,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
+@SuppressWarnings("PMD.TooManyMethods")
 public class TradeItemControllerIntegrationTest extends BaseWebIntegrationTest {
 
   private static final String RESOURCE_URL = "/api/tradeItems";
   private static final String CID = "cid";
+  private static final String GTIN = "gtin";
   private static final String MANUFACTURER_ONE_NAME = "one";
   private static final String GTIN_ONE = "96385074";
   private static final String MANUFACTURER_TWO_NAME = "two";
@@ -210,7 +212,7 @@ public class TradeItemControllerIntegrationTest extends BaseWebIntegrationTest {
     PageDto response = restAssured
         .given()
         .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
-        .queryParam("gtin", GTIN_14)
+        .queryParam(GTIN, GTIN_14)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .when()
         .get(RESOURCE_URL)
@@ -232,7 +234,7 @@ public class TradeItemControllerIntegrationTest extends BaseWebIntegrationTest {
     PageDto response = restAssured
         .given()
         .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
-        .queryParam("gtin", GTIN_13)
+        .queryParam(GTIN, GTIN_13)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .when()
         .get(RESOURCE_URL)
@@ -252,7 +254,7 @@ public class TradeItemControllerIntegrationTest extends BaseWebIntegrationTest {
     PageDto response = restAssured
         .given()
         .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
-        .queryParam("gtin", GTIN_14)
+        .queryParam(GTIN, GTIN_14)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .when()
         .get(RESOURCE_URL)
@@ -270,7 +272,7 @@ public class TradeItemControllerIntegrationTest extends BaseWebIntegrationTest {
 
     restAssured
         .given()
-        .queryParam("gtin", GTIN_14)
+        .queryParam(GTIN, GTIN_14)
         .when()
         .get(RESOURCE_URL)
         .then()
@@ -406,7 +408,7 @@ public class TradeItemControllerIntegrationTest extends BaseWebIntegrationTest {
           retrieved.get("manufacturerOfTradeItem"));
       String expectedGtin = (expected.get(i).getGtin() == null)
           ? null : expected.get(i).getGtin().toString();
-      assertEquals(expectedGtin, retrieved.get("gtin"));
+      assertEquals(expectedGtin, retrieved.get(GTIN));
     }
   }
 }

--- a/src/main/java/org/openlmis/referencedata/domain/Gtin.java
+++ b/src/main/java/org/openlmis/referencedata/domain/Gtin.java
@@ -15,9 +15,13 @@
 
 package org.openlmis.referencedata.domain;
 
+import static java.util.Arrays.asList;
+import static org.openlmis.referencedata.util.messagekeys.TradeItemMessageKeys.ERROR_GTIN_INVALID_CHECK_DIGIT;
 import static org.openlmis.referencedata.util.messagekeys.TradeItemMessageKeys.ERROR_GTIN_INVALID_LENGTH;
 import static org.openlmis.referencedata.util.messagekeys.TradeItemMessageKeys.ERROR_GTIN_NUMERIC;
 
+import java.util.List;
+import java.util.regex.Pattern;
 import javax.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -26,11 +30,20 @@ import org.openlmis.referencedata.exception.ValidationMessageException;
 import org.openlmis.referencedata.util.Message;
 
 /**
- * Global Trade Item Number, associated with TradeItem.
+ * Global Trade Item Number, associated with TradeItem. Values are stored zero-padded to 14 digits,
+ * so a lookup by the scanned, always 14-digit value matches a shorter registered structure.
  */
 @Embeddable
 @EqualsAndHashCode
 public class Gtin {
+
+  private static final int LENGTH = 14;
+
+  private static final List<Integer> VALID_LENGTHS = asList(8, 12, 13, LENGTH);
+
+  // not StringUtils.isNumeric, which accepts any Unicode digit - a scanner emits only ASCII ones
+  private static final String DIGITS_REGEX = "[0-9]+";
+  private static final Pattern DIGITS_PATTERN = Pattern.compile(DIGITS_REGEX);
 
   @Getter
   private String gtin;
@@ -38,18 +51,55 @@ public class Gtin {
   private Gtin() { }
 
   /**
-   * Creates a new Gtin value.
+   * Creates a new Gtin value, validated against the GS1 General Specification (digits, GTIN
+   * length, check digit) and normalized to 14 digits.
+   *
    * @param gtin the gtin
+   * @throws ValidationMessageException if the value is not a valid GTIN
    */
   public Gtin(String gtin) {
-    if (!StringUtils.isNumeric(gtin)) {
+    if (gtin == null || !DIGITS_PATTERN.matcher(gtin).matches()) {
       throw new ValidationMessageException(
           new Message(ERROR_GTIN_NUMERIC));
     }
-    if (gtin.length() < 8 || gtin.length() > 14) {
+    if (!VALID_LENGTHS.contains(gtin.length())) {
       throw new ValidationMessageException(
           new Message(ERROR_GTIN_INVALID_LENGTH));
     }
-    this.gtin = gtin;
+    if (!hasValidCheckDigit(gtin)) {
+      throw new ValidationMessageException(
+          new Message(ERROR_GTIN_INVALID_CHECK_DIGIT));
+    }
+    this.gtin = normalize(gtin);
+  }
+
+  /**
+   * Zero-pads the given value to the 14-digit stored form. Performs no validation, so it can
+   * normalize search criteria without rejecting values that simply will not match.
+   *
+   * @param gtin the gtin, may be null
+   * @return the padded value, or the value itself when null or not shorter than 14 characters
+   */
+  public static String normalize(String gtin) {
+    return gtin == null ? null : StringUtils.leftPad(gtin, LENGTH, '0');
+  }
+
+  /**
+   * Verifies the GS1 modulo-10 check digit. Leading zeros do not affect the sum, so the result
+   * is the same before and after normalization.
+   */
+  private static boolean hasValidCheckDigit(String gtin) {
+    int lastIndex = gtin.length() - 1;
+    int sum = 0;
+
+    for (int i = 0; i < lastIndex; ++i) {
+      int digit = Character.digit(gtin.charAt(i), 10);
+      // digits are weighted alternately, 3 for the digit next to the check digit
+      sum += ((lastIndex - i) % 2 == 0) ? digit : digit * 3;
+    }
+
+    int checkDigit = (10 - (sum % 10)) % 10;
+
+    return checkDigit == Character.digit(gtin.charAt(lastIndex), 10);
   }
 }

--- a/src/main/java/org/openlmis/referencedata/repository/TradeItemRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/TradeItemRepository.java
@@ -16,6 +16,7 @@
 package org.openlmis.referencedata.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.openlmis.referencedata.domain.TradeItem;
 import org.openlmis.referencedata.dto.TradeItemCsvModel;
@@ -24,6 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TradeItemRepository
     extends JpaRepository<TradeItem, UUID>, TradeItemRepositoryCustom,
@@ -49,5 +51,14 @@ public interface TradeItemRepository
 
   @Query(nativeQuery = true)
   List<TradeItemCsvModel> findAllTradeItemCsvModels();
+
+  /**
+   * Finds the trade item registered with the given GTIN, by equality on the indexed column.
+   *
+   * @param gtin the normalized, 14-digit GTIN
+   * @return the matching trade item, if any
+   */
+  @Query("SELECT t FROM TradeItem t WHERE t.gtin.gtin = :gtin")
+  Optional<TradeItem> findByGtin(@Param("gtin") String gtin);
 
 }

--- a/src/main/java/org/openlmis/referencedata/service/TradeItemSearchParams.java
+++ b/src/main/java/org/openlmis/referencedata/service/TradeItemSearchParams.java
@@ -31,4 +31,5 @@ public class TradeItemSearchParams {
   private Set<UUID> id;
   private String classificationId;
   private boolean fullMatch;
+  private String gtin;
 }

--- a/src/main/java/org/openlmis/referencedata/service/TradeItemService.java
+++ b/src/main/java/org/openlmis/referencedata/service/TradeItemService.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.StringUtils;
+import org.openlmis.referencedata.domain.Gtin;
 import org.openlmis.referencedata.domain.TradeItem;
 import org.openlmis.referencedata.dto.TradeItemCsvModel;
 import org.openlmis.referencedata.repository.TradeItemRepository;
@@ -51,16 +52,28 @@ public class TradeItemService implements ExportableDataService<TradeItemCsvModel
 
   /**
    * Searches for trade items matching the given parameters. Filters are applied with the following
-   * precedence: if any {@code id} is provided, trade items are looked up by those identifiers and
-   * the remaining filters are ignored; otherwise, if a {@code classificationId} is provided, it is
+   * precedence: if a {@code gtin} is provided, the trade item registered with it is returned and
+   * the remaining filters are ignored; otherwise, if any {@code id} is provided, trade items are
+   * looked up by those identifiers; otherwise, if a {@code classificationId} is provided, it is
    * matched either fully or partially depending on the {@code fullMatch} flag; when no filter is
-   * provided, all trade items are returned.
+   * provided, all trade items are returned. The {@code gtin} is normalized but not validated - a
+   * value that cannot identify a trade item simply matches nothing.
    *
-   * @param requestParams the search parameters (trade item ids, classification id, full match flag)
+   * @param requestParams the search parameters (gtin, trade item ids, classification id, full match
+   *                      flag)
    * @param pageable      the pagination parameters
    * @return a page of matching trade items
    */
   public Page<TradeItem> search(@NotNull TradeItemSearchParams requestParams, Pageable pageable) {
+    String gtin = requestParams.getGtin();
+    if (StringUtils.isNotBlank(gtin)) {
+      List<TradeItem> found = tradeItemRepository
+          .findByGtin(Gtin.normalize(gtin))
+          .map(Collections::singletonList)
+          .orElse(Collections.emptyList());
+      return Pagination.getPage(found, pageable);
+    }
+
     final Set<UUID> id = Optional.ofNullable(requestParams.getId()).orElse(Collections.emptySet());
     if (!id.isEmpty()) {
       return Pagination.getPage(tradeItemRepository.findAllById(id), pageable);

--- a/src/main/java/org/openlmis/referencedata/util/messagekeys/MessageKeys.java
+++ b/src/main/java/org/openlmis/referencedata/util/messagekeys/MessageKeys.java
@@ -61,6 +61,7 @@ public abstract class MessageKeys {
   protected static final String MUST_BE_PROVIDED = "mustBeProvided";
   protected static final String MISMATCH = "mismatch";
   protected static final String INVALID_LENGTH = "invalidLength";
+  protected static final String INVALID_CHECK_DIGIT = "invalidCheckDigit";
   protected static final String INVALID_PARAMS = "invalidParams";
   protected static final String FORMAT = "format";
   protected static final String UUID = "uuid";

--- a/src/main/java/org/openlmis/referencedata/util/messagekeys/TradeItemMessageKeys.java
+++ b/src/main/java/org/openlmis/referencedata/util/messagekeys/TradeItemMessageKeys.java
@@ -17,6 +17,7 @@ package org.openlmis.referencedata.util.messagekeys;
 
 public abstract class TradeItemMessageKeys extends MessageKeys {
   private static final String ERROR = join(SERVICE_ERROR, TRADE_ITEM);
+  private static final String GTIN = "gtin";
 
   public static final String ERROR_NOT_FOUND_WITH_ID = join(ERROR, NOT_FOUND, WITH, ID);
   public static final String ERROR_NULL = join(ERROR, NULL);
@@ -25,9 +26,11 @@ public abstract class TradeItemMessageKeys extends MessageKeys {
       join(ERROR, "manufacturerOfTradeItem", REQUIRED);
 
   public static final String ERROR_GTIN_NUMERIC =
-      join(ERROR, "gtin", NUMERIC);
+      join(ERROR, GTIN, NUMERIC);
   public static final String ERROR_GTIN_INVALID_LENGTH =
-      join(ERROR, "gtin", INVALID_LENGTH);
+      join(ERROR, GTIN, INVALID_LENGTH);
+  public static final String ERROR_GTIN_INVALID_CHECK_DIGIT =
+      join(ERROR, GTIN, INVALID_CHECK_DIGIT);
   public static final String ERROR_GTIN_DUPLICATED =
-      join(ERROR, "gtin", DUPLICATED);
+      join(ERROR, GTIN, DUPLICATED);
 }

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -911,8 +911,14 @@ resourceTypes:
                       schema: localizedErrorResponse
       get:
           is: [ secured, paginated ]
-          description: Retrieve trade items. Optionally filter by trade item IDs, or by the classification ID using either a full or partial match.
+          description: Retrieve trade items. Optionally filter by GTIN, by trade item IDs, or by the classification ID using either a full or partial match. The gtin filter takes precedence.
           queryParameters:
+              gtin:
+                      displayName: gtin
+                      description: GTIN of the trade item, matched in the stored 14-digit form, so a GTIN-8, GTIN-12 or GTIN-13 value resolves the same trade item. Returns at most one.
+                      type: string
+                      required: false
+                      repeat: false
               id:
                       displayName: id
                       type: string

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -82,6 +82,7 @@ referenceData.error.tradeItem.null=Trade item cannot be null
 referenceData.error.tradeItem.manufacturerOfTradeItem.required=manufacturerOfTradeItem is required
 referenceData.error.tradeItem.gtin.numeric=GTIN should be numeric
 referenceData.error.tradeItem.gtin.invalidLength=GTIN should be between 8 and 14 digits long
+referenceData.error.tradeItem.gtin.invalidCheckDigit=GTIN has an invalid check digit
 referenceData.error.tradeItem.gtin.duplicated=GTIN is not unique
 referenceData.error.orderable.null=Orderable cannot be null
 referenceData.error.orderable.notFound=Orderable not found

--- a/src/main/resources/schemas/tradeItem.json
+++ b/src/main/resources/schemas/tradeItem.json
@@ -14,7 +14,8 @@
     },
     "gtin": {
       "type": "string",
-      "title": "gtin"
+      "title": "gtin",
+      "description": "Global Trade Item Number, accepted as GTIN-8/12/13/14 with a valid check digit and returned zero-padded to 14 digits."
     },
     "classifications": {
       "type": "array",

--- a/src/test/java/org/openlmis/referencedata/domain/GtinTest.java
+++ b/src/test/java/org/openlmis/referencedata/domain/GtinTest.java
@@ -17,16 +17,31 @@ package org.openlmis.referencedata.domain;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.openlmis.referencedata.util.messagekeys.TradeItemMessageKeys.ERROR_GTIN_INVALID_CHECK_DIGIT;
+import static org.openlmis.referencedata.util.messagekeys.TradeItemMessageKeys.ERROR_GTIN_INVALID_LENGTH;
+import static org.openlmis.referencedata.util.messagekeys.TradeItemMessageKeys.ERROR_GTIN_NUMERIC;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.openlmis.referencedata.exception.ValidationMessageException;
 
+@SuppressWarnings("PMD.TooManyMethods")
 public class GtinTest {
 
-  private Gtin gtin1 = new Gtin("11111111111111");
-  private Gtin gtin2 = new Gtin("22222222");
+  private static final String GTIN_8 = "96385074";
+  private static final String GTIN_12 = "614141000036";
+  private static final String GTIN_13 = "5901234123457";
+  private static final String GTIN_14 = "05890123456786";
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private Gtin gtin1 = new Gtin("11111111111113");
+  private Gtin gtin2 = new Gtin("22222220");
 
   @Test
   public void shouldBeEqualByGtin() {
@@ -54,18 +69,133 @@ public class GtinTest {
         .verify();
   }
 
-  @Test(expected = ValidationMessageException.class)
+  @Test
+  public void shouldKeepGtin14AsIs() {
+    assertEquals(GTIN_14, new Gtin(GTIN_14).getGtin());
+  }
+
+  @Test
+  public void shouldPadGtin13To14Digits() {
+    assertEquals("05901234123457", new Gtin(GTIN_13).getGtin());
+  }
+
+  @Test
+  public void shouldPadGtin12To14Digits() {
+    assertEquals("00614141000036", new Gtin(GTIN_12).getGtin());
+  }
+
+  @Test
+  public void shouldPadGtin8To14Digits() {
+    assertEquals("00000096385074", new Gtin(GTIN_8).getGtin());
+  }
+
+  @Test
+  public void shouldBeEqualToTheSameGtinInAnotherStructure() {
+    assertEquals(new Gtin(GTIN_13), new Gtin("05901234123457"));
+    assertEquals(new Gtin(GTIN_8), new Gtin("00000096385074"));
+  }
+
+  @Test
   public void shouldThrowExceptionIfGtinIsNotNumeric() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_NUMERIC);
+
     new Gtin("ab12345678ba");
   }
 
-  @Test(expected = ValidationMessageException.class)
+  @Test
+  public void shouldThrowExceptionIfGtinUsesNonAsciiDigits() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_NUMERIC);
+
+    // Arabic-Indic digits for 96385074 - accepted by Character.isDigit, unusable by a scanner
+    new Gtin(new String(new char[] {0x0669, 0x0666, 0x0663, 0x0668, 0x0665, 0x0660, 0x0667,
+        0x0664}));
+  }
+
+  @Test
+  public void shouldThrowExceptionIfGtinIsNull() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_NUMERIC);
+
+    new Gtin(null);
+  }
+
+  @Test
+  public void shouldThrowExceptionIfGtinIsEmpty() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_NUMERIC);
+
+    new Gtin("");
+  }
+
+  @Test
   public void shouldThrowExceptionIfGtinIsTooShort() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_INVALID_LENGTH);
+
     new Gtin("1234567");
   }
 
-  @Test(expected = ValidationMessageException.class)
+  @Test
   public void shouldThrowExceptionIfGtinIsTooLong() {
-    new Gtin("123456789012345");
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_INVALID_LENGTH);
+
+    new Gtin("059012341234570");
+  }
+
+  @Test
+  public void shouldThrowExceptionIfGtinHasLengthBetweenDefinedStructures() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_INVALID_LENGTH);
+
+    // 9, 10 and 11 digits are not GTIN structures, but were accepted before
+    new Gtin("963850740");
+  }
+
+  @Test
+  public void shouldThrowExceptionIfGtinHasTenDigits() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_INVALID_LENGTH);
+
+    new Gtin("9638507400");
+  }
+
+  @Test
+  public void shouldThrowExceptionIfGtinHasElevenDigits() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_INVALID_LENGTH);
+
+    new Gtin("96385074000");
+  }
+
+  @Test
+  public void shouldThrowExceptionIfCheckDigitIsInvalid() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_INVALID_CHECK_DIGIT);
+
+    new Gtin("05890123456787");
+  }
+
+  @Test
+  public void shouldThrowExceptionIfCheckDigitOfShorterStructureIsInvalid() {
+    expectedException.expect(ValidationMessageException.class);
+    expectedException.expectMessage(ERROR_GTIN_INVALID_CHECK_DIGIT);
+
+    new Gtin("96385075");
+  }
+
+  @Test
+  public void shouldNormalizeToFourteenDigits() {
+    assertEquals("05901234123457", Gtin.normalize(GTIN_13));
+    assertEquals("00000096385074", Gtin.normalize(GTIN_8));
+  }
+
+  @Test
+  public void shouldNotChangeValueThatCannotBeNormalized() {
+    assertNull(Gtin.normalize(null));
+    assertEquals(GTIN_14, Gtin.normalize(GTIN_14));
+    assertEquals("059012341234570", Gtin.normalize("059012341234570"));
   }
 }

--- a/src/test/java/org/openlmis/referencedata/service/TradeItemServiceTest.java
+++ b/src/test/java/org/openlmis/referencedata/service/TradeItemServiceTest.java
@@ -50,6 +50,8 @@ public class TradeItemServiceTest {
   private static final String GTIN_13 = "5901234123457";
   private static final String PADDED_GTIN_13 = "05901234123457";
   private static final String GTIN_14 = "05890123456786";
+  private static final String NOT_A_GTIN = "not-a-gtin";
+  private static final String PADDED_NOT_A_GTIN = "0000" + NOT_A_GTIN;
 
   @Mock
   private TradeItemRepository tradeItemRepository;
@@ -154,17 +156,19 @@ public class TradeItemServiceTest {
 
     Page<TradeItem> result = service.search(params, PAGEABLE);
 
+    verify(tradeItemRepository).findByGtin(GTIN_14);
     assertEquals(0, result.getContent().size());
     assertEquals(0, result.getTotalElements());
   }
 
   @Test
   public void shouldReturnEmptyPageWhenGtinCannotMatchAnyTradeItem() {
-    TradeItemSearchParams params = new TradeItemSearchParams(null, null, false, "not-a-gtin");
-    when(tradeItemRepository.findByGtin("0000not-a-gtin")).thenReturn(Optional.empty());
+    TradeItemSearchParams params = new TradeItemSearchParams(null, null, false, NOT_A_GTIN);
+    when(tradeItemRepository.findByGtin(PADDED_NOT_A_GTIN)).thenReturn(Optional.empty());
 
     Page<TradeItem> result = service.search(params, PAGEABLE);
 
+    verify(tradeItemRepository).findByGtin(PADDED_NOT_A_GTIN);
     assertEquals(0, result.getContent().size());
   }
 

--- a/src/test/java/org/openlmis/referencedata/service/TradeItemServiceTest.java
+++ b/src/test/java/org/openlmis/referencedata/service/TradeItemServiceTest.java
@@ -16,11 +16,15 @@
 package org.openlmis.referencedata.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.assertj.core.util.Lists;
@@ -39,9 +43,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 @RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("PMD.TooManyMethods")
 public class TradeItemServiceTest {
 
   private static final Pageable PAGEABLE = PageRequest.of(0, 10);
+  private static final String GTIN_13 = "5901234123457";
+  private static final String PADDED_GTIN_13 = "05901234123457";
+  private static final String GTIN_14 = "05890123456786";
 
   @Mock
   private TradeItemRepository tradeItemRepository;
@@ -76,7 +84,7 @@ public class TradeItemServiceTest {
   public void shouldSearchTradeItemsByIds() {
     TradeItem tradeItem = new TradeItemDataBuilder().build();
     Set<UUID> ids = Collections.singleton(tradeItem.getId());
-    TradeItemSearchParams params = new TradeItemSearchParams(ids, null, false);
+    TradeItemSearchParams params = new TradeItemSearchParams(ids, null, false, null);
     when(tradeItemRepository.findAllById(ids)).thenReturn(Lists.newArrayList(tradeItem));
 
     Page<TradeItem> result = service.search(params, PAGEABLE);
@@ -90,7 +98,7 @@ public class TradeItemServiceTest {
   public void shouldSearchTradeItemsByClassificationIdWithFullMatch() {
     TradeItem tradeItem = new TradeItemDataBuilder().build();
     String classificationId = "classification-1";
-    TradeItemSearchParams params = new TradeItemSearchParams(null, classificationId, true);
+    TradeItemSearchParams params = new TradeItemSearchParams(null, classificationId, true, null);
     when(tradeItemRepository.findByClassificationId(classificationId))
         .thenReturn(Lists.newArrayList(tradeItem));
 
@@ -104,7 +112,7 @@ public class TradeItemServiceTest {
   public void shouldSearchTradeItemsByClassificationIdWithPartialMatch() {
     TradeItem tradeItem = new TradeItemDataBuilder().build();
     String classificationId = "classification";
-    TradeItemSearchParams params = new TradeItemSearchParams(null, classificationId, false);
+    TradeItemSearchParams params = new TradeItemSearchParams(null, classificationId, false, null);
     when(tradeItemRepository.findByClassificationIdLike(classificationId))
         .thenReturn(Lists.newArrayList(tradeItem));
 
@@ -115,9 +123,84 @@ public class TradeItemServiceTest {
   }
 
   @Test
+  public void shouldSearchTradeItemsByGtin() {
+    TradeItem tradeItem = new TradeItemDataBuilder().build();
+    TradeItemSearchParams params = new TradeItemSearchParams(null, null, false, GTIN_14);
+    when(tradeItemRepository.findByGtin(GTIN_14)).thenReturn(Optional.of(tradeItem));
+
+    Page<TradeItem> result = service.search(params, PAGEABLE);
+
+    verify(tradeItemRepository).findByGtin(GTIN_14);
+    assertEquals(1, result.getContent().size());
+    assertEquals(tradeItem, result.getContent().get(0));
+  }
+
+  @Test
+  public void shouldNormalizeGtinBeforeSearching() {
+    TradeItem tradeItem = new TradeItemDataBuilder().build();
+    TradeItemSearchParams params = new TradeItemSearchParams(null, null, false, GTIN_13);
+    when(tradeItemRepository.findByGtin(PADDED_GTIN_13)).thenReturn(Optional.of(tradeItem));
+
+    Page<TradeItem> result = service.search(params, PAGEABLE);
+
+    verify(tradeItemRepository).findByGtin(PADDED_GTIN_13);
+    assertEquals(1, result.getContent().size());
+  }
+
+  @Test
+  public void shouldReturnEmptyPageWhenNoTradeItemIsRegisteredWithGtin() {
+    TradeItemSearchParams params = new TradeItemSearchParams(null, null, false, GTIN_14);
+    when(tradeItemRepository.findByGtin(GTIN_14)).thenReturn(Optional.empty());
+
+    Page<TradeItem> result = service.search(params, PAGEABLE);
+
+    assertEquals(0, result.getContent().size());
+    assertEquals(0, result.getTotalElements());
+  }
+
+  @Test
+  public void shouldReturnEmptyPageWhenGtinCannotMatchAnyTradeItem() {
+    TradeItemSearchParams params = new TradeItemSearchParams(null, null, false, "not-a-gtin");
+    when(tradeItemRepository.findByGtin("0000not-a-gtin")).thenReturn(Optional.empty());
+
+    Page<TradeItem> result = service.search(params, PAGEABLE);
+
+    assertEquals(0, result.getContent().size());
+  }
+
+  @Test
+  public void shouldIgnoreOtherFiltersWhenGtinIsProvided() {
+    TradeItem tradeItem = new TradeItemDataBuilder().build();
+    TradeItemSearchParams params = new TradeItemSearchParams(
+        Collections.singleton(UUID.randomUUID()), "classification-1", true, GTIN_14);
+    when(tradeItemRepository.findByGtin(GTIN_14)).thenReturn(Optional.of(tradeItem));
+
+    Page<TradeItem> result = service.search(params, PAGEABLE);
+
+    assertEquals(1, result.getContent().size());
+    verify(tradeItemRepository).findByGtin(GTIN_14);
+    verify(tradeItemRepository, never()).findAllById(any());
+    verify(tradeItemRepository, never()).findByClassificationId(anyString());
+  }
+
+  @Test
+  public void shouldIgnoreBlankGtin() {
+    TradeItem tradeItem = new TradeItemDataBuilder().build();
+    TradeItemSearchParams params = new TradeItemSearchParams(null, null, false, " ");
+    Page<TradeItem> page = new PageImpl<>(Lists.newArrayList(tradeItem));
+    when(tradeItemRepository.findAll(PAGEABLE)).thenReturn(page);
+
+    Page<TradeItem> result = service.search(params, PAGEABLE);
+
+    verify(tradeItemRepository).findAll(PAGEABLE);
+    verify(tradeItemRepository, never()).findByGtin(anyString());
+    assertEquals(1, result.getContent().size());
+  }
+
+  @Test
   public void shouldReturnAllTradeItemsWhenNoParamsProvided() {
     TradeItem tradeItem = new TradeItemDataBuilder().build();
-    TradeItemSearchParams params = new TradeItemSearchParams(null, null, false);
+    TradeItemSearchParams params = new TradeItemSearchParams(null, null, false, null);
     Page<TradeItem> page = new PageImpl<>(Lists.newArrayList(tradeItem));
     when(tradeItemRepository.findAll(PAGEABLE)).thenReturn(page);
 


### PR DESCRIPTION
Task:
https://openlmis.atlassian.net/browse/OLMIS-8287
Description:
Adds a `gtin` filter to `GET /api/tradeItems` so a scanned GTIN resolves to a trade item.

**Changes**

* Added `gtin` filter to `GET /api/tradeItems` (takes precedence over other filters, returns 0..1 result).
* `Gtin` is normalized to 14 digits (zero-padded) on write and validated according to GS1 (supported lengths: 8/12/13/14, valid check digit, ASCII digits).
* Added repository support for GTIN lookup.
