### PR TITLE
[OLMIS-8289] Add gtin column to trade item CSV import and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Improvements:
 * GET `/tradeItems` now supports a repeatable `id` query parameter to filter trade items by their identifiers.
 * [OLMIS-8118](https://openlmis.atlassian.net/browse/OLMIS-8118): Reject kit child quantity exceeding Integer max.
 * [OLMIS-8287](https://openlmis.atlassian.net/browse/OLMIS-8287): GET `/tradeItems` now supports a `gtin` query parameter; GTINs are normalized to 14 digits and validated (length, GS1 check digit) on write.
+* [OLMIS-8289](https://openlmis.atlassian.net/browse/OLMIS-8289): The trade item CSV import now accepts an optional `gtin` column, normalized and validated on write like any other GTIN. Files without the column import as before. Because import and export share one model, the trade item CSV export now includes a `gtin` column as well - existing export consumers will see the extra column.
 
 15.5.0 / 2026-06-09
 ==================

--- a/src/integration-test/java/org/openlmis/referencedata/service/DataImportServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/referencedata/service/DataImportServiceIntegrationTest.java
@@ -17,6 +17,7 @@ package org.openlmis.referencedata.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -48,6 +49,7 @@ import org.mockito.Mock;
 import org.openlmis.referencedata.Application;
 import org.openlmis.referencedata.domain.Code;
 import org.openlmis.referencedata.domain.Dispensable;
+import org.openlmis.referencedata.domain.Gtin;
 import org.openlmis.referencedata.domain.Orderable;
 import org.openlmis.referencedata.domain.OrderableDisplayCategory;
 import org.openlmis.referencedata.domain.Program;
@@ -55,6 +57,7 @@ import org.openlmis.referencedata.domain.ProgramOrderable;
 import org.openlmis.referencedata.domain.TradeItem;
 import org.openlmis.referencedata.dto.DispensableDto;
 import org.openlmis.referencedata.dto.ImportResponseDto;
+import org.openlmis.referencedata.dto.TradeItemCsvModel;
 import org.openlmis.referencedata.repository.OrderableDisplayCategoryRepository;
 import org.openlmis.referencedata.repository.OrderableRepository;
 import org.openlmis.referencedata.repository.ProgramOrderableRepository;
@@ -189,6 +192,18 @@ public class DataImportServiceIntegrationTest {
       Arrays.asList(ORDERABLE_CODE_1, ITEM_MANUFACTURER_1),
       Arrays.asList(ORDERABLE_CODE_2, ITEM_MANUFACTURER_2),
       Arrays.asList(ORDERABLE_CODE_3, ITEM_MANUFACTURER_3)
+  );
+
+  private static final String GTIN_13 = "4006381333931";
+  private static final String GTIN_13_PADDED = "04006381333931";
+  private static final String GTIN_8 = "96385074";
+  private static final String GTIN_8_PADDED = "00000096385074";
+  private static final List<String> TRADE_ITEM_GTIN_HEADERS = Arrays.asList(
+      "productCode", "manufacturerOfTradeItem", "gtin");
+  private static final List<List<String>> TRADE_ITEM_GTIN_RECORDS = Arrays.asList(
+      Arrays.asList(ORDERABLE_CODE_1, ITEM_MANUFACTURER_1, GTIN_13),
+      Arrays.asList(ORDERABLE_CODE_2, ITEM_MANUFACTURER_2, GTIN_8),
+      Arrays.asList(ORDERABLE_CODE_3, ITEM_MANUFACTURER_3, "")
   );
 
   private Program persistedProgram;
@@ -348,19 +363,7 @@ public class DataImportServiceIntegrationTest {
   @Test
   public void shouldImportTradeItemFromValidCsvFile() throws IOException, InterruptedException {
     // given
-    final TradeItem persistedTradeItem1 = createAndPersistTradeItem(TEST_MANUFACTURER);
-    final TradeItem persistedTradeItem2 = createAndPersistTradeItem(TEST_MANUFACTURER);
-
-    createAndPersistOrderable(
-        ORDERABLE_CODE_1, TEST_NAME, TEST_DISPENSABLE,
-        Pair.of(COMMODITY_TYPE, persistedTradeItem1.getId().toString()));
-
-    createAndPersistOrderable(
-        ORDERABLE_CODE_2, TEST_NAME, TEST_DISPENSABLE,
-        Pair.of(TRADE_ITEM, persistedTradeItem2.getId().toString()));
-
-    createAndPersistOrderable(
-        ORDERABLE_CODE_3, TEST_NAME, TEST_DISPENSABLE);
+    setUpThreeOrderableTradeItemFixture();
 
     MockMultipartFile multipartFile = createZippedCsv(TRADE_ITEM_CORRECT_RECORDS,
         TRADE_ITEM_CORRECT_HEADERS, TRADE_ITEM_FILE);
@@ -371,24 +374,16 @@ public class DataImportServiceIntegrationTest {
 
     // then check if result is present
     assertNotNull(result);
-    assertEquals((Integer) ORDERABLE_CORRECT_RECORDS.size(),
+    assertEquals((Integer) TRADE_ITEM_CORRECT_RECORDS.size(),
         result.get(0).getSuccessfulEntriesCount());
 
     // then fetch imported objects
-    final Orderable importedOrderable1 = orderableRepository
-        .findFirstByProductCodeOrderByIdentityVersionNumberDesc(Code.code(ORDERABLE_CODE_1));
-    final TradeItem importedTradeItem1 = tradeItemRepository.findById(
-        UUID.fromString(importedOrderable1.getTradeItemIdentifier())).get();
-
-    final Orderable importedOrderable2 = orderableRepository
-        .findFirstByProductCodeOrderByIdentityVersionNumberDesc(Code.code(ORDERABLE_CODE_2));
-    final TradeItem importedTradeItem2 = tradeItemRepository.findById(
-        UUID.fromString(importedOrderable2.getTradeItemIdentifier())).get();
-
-    final Orderable importedOrderable3 = orderableRepository
-        .findFirstByProductCodeOrderByIdentityVersionNumberDesc(Code.code(ORDERABLE_CODE_3));
-    final TradeItem importedTradeItem3 = tradeItemRepository.findById(
-        UUID.fromString(importedOrderable3.getTradeItemIdentifier())).get();
+    final Orderable importedOrderable1 = fetchImportedOrderable(ORDERABLE_CODE_1);
+    final TradeItem importedTradeItem1 = fetchImportedTradeItem(ORDERABLE_CODE_1);
+    final Orderable importedOrderable2 = fetchImportedOrderable(ORDERABLE_CODE_2);
+    final TradeItem importedTradeItem2 = fetchImportedTradeItem(ORDERABLE_CODE_2);
+    final Orderable importedOrderable3 = fetchImportedOrderable(ORDERABLE_CODE_3);
+    final TradeItem importedTradeItem3 = fetchImportedTradeItem(ORDERABLE_CODE_3);
 
     // then check if orderable with commodityType identifier was updated
     assertTrue(importedOrderable1.getIdentifiers().containsKey(TRADE_ITEM));
@@ -407,6 +402,84 @@ public class DataImportServiceIntegrationTest {
     assertEquals(importedOrderable3.getTradeItemIdentifier(),
         importedTradeItem3.getId().toString());
     assertEquals(importedTradeItem3.getManufacturerOfTradeItem(), ITEM_MANUFACTURER_3);
+  }
+
+  @Test
+  public void shouldImportTradeItemWithGtinFromValidCsvFile()
+      throws IOException, InterruptedException {
+    // given
+    setUpThreeOrderableTradeItemFixture();
+
+    MockMultipartFile multipartFile = createZippedCsv(TRADE_ITEM_GTIN_RECORDS,
+        TRADE_ITEM_GTIN_HEADERS, TRADE_ITEM_FILE);
+
+    // when
+    List<ImportResponseDto.ImportDetails> result =
+        dataImportService.importData(multipartFile, profiler);
+
+    // then
+    assertNotNull(result);
+    assertEquals((Integer) TRADE_ITEM_GTIN_RECORDS.size(),
+        result.get(0).getSuccessfulEntriesCount());
+
+    final TradeItem importedTradeItem1 = fetchImportedTradeItem(ORDERABLE_CODE_1);
+    final TradeItem importedTradeItem2 = fetchImportedTradeItem(ORDERABLE_CODE_2);
+    final TradeItem importedTradeItem3 = fetchImportedTradeItem(ORDERABLE_CODE_3);
+
+    // a shorter GTIN is stored zero-padded to the 14-digit form (create path)
+    assertEquals(GTIN_13_PADDED, importedTradeItem1.getGtin().getGtin());
+    // and via the update path onto an existing trade item
+    assertEquals(GTIN_8_PADDED, importedTradeItem2.getGtin().getGtin());
+    // a blank gtin cell registers no GTIN
+    assertNull(importedTradeItem3.getGtin());
+  }
+
+  @Test
+  public void shouldIncludeGtinInExportableTradeItemCsvModels() {
+    // given a trade item that carries a (short) GTIN, linked to an orderable
+    TradeItem tradeItem = new TradeItemDataBuilder()
+        .withManufacturerOfTradeItem(TEST_MANUFACTURER)
+        .buildAsNew();
+    tradeItem.setGtin(new Gtin(GTIN_8));
+    tradeItemRepository.saveAndFlush(tradeItem);
+
+    createAndPersistOrderable(
+        ORDERABLE_CODE_1, TEST_NAME, TEST_DISPENSABLE,
+        Pair.of(TRADE_ITEM, tradeItem.getId().toString()));
+
+    // when the shared export projection is read
+    List<TradeItemCsvModel> exported = tradeItemRepository.findAllTradeItemCsvModels();
+
+    // then it carries the stored (normalized) GTIN alongside code and manufacturer
+    TradeItemCsvModel exportedModel = exported.stream()
+        .filter(model -> ORDERABLE_CODE_1.equals(model.getCode()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("no exported model for code " + ORDERABLE_CODE_1));
+    assertEquals(GTIN_8_PADDED, exportedModel.getGtin());
+    assertEquals(TEST_MANUFACTURER, exportedModel.getManufacturerOfTradeItem());
+  }
+
+  private void setUpThreeOrderableTradeItemFixture() {
+    final TradeItem persistedTradeItem1 = createAndPersistTradeItem(TEST_MANUFACTURER);
+    final TradeItem persistedTradeItem2 = createAndPersistTradeItem(TEST_MANUFACTURER);
+
+    createAndPersistOrderable(
+        ORDERABLE_CODE_1, TEST_NAME, TEST_DISPENSABLE,
+        Pair.of(COMMODITY_TYPE, persistedTradeItem1.getId().toString()));
+    createAndPersistOrderable(
+        ORDERABLE_CODE_2, TEST_NAME, TEST_DISPENSABLE,
+        Pair.of(TRADE_ITEM, persistedTradeItem2.getId().toString()));
+    createAndPersistOrderable(ORDERABLE_CODE_3, TEST_NAME, TEST_DISPENSABLE);
+  }
+
+  private Orderable fetchImportedOrderable(String orderableCode) {
+    return orderableRepository
+        .findFirstByProductCodeOrderByIdentityVersionNumberDesc(Code.code(orderableCode));
+  }
+
+  private TradeItem fetchImportedTradeItem(String orderableCode) {
+    return tradeItemRepository.findById(
+        UUID.fromString(fetchImportedOrderable(orderableCode).getTradeItemIdentifier())).get();
   }
 
   private void assertOrderables(Orderable importedOrderable, String name, String description,

--- a/src/main/java/org/openlmis/referencedata/domain/TradeItem.java
+++ b/src/main/java/org/openlmis/referencedata/domain/TradeItem.java
@@ -52,7 +52,7 @@ import org.openlmis.referencedata.dto.TradeItemCsvModel;
  */
 @NamedNativeQueries(
         @NamedNativeQuery(name = "TradeItem.findAllTradeItemCsvModels",
-                query = "select ti.manufactureroftradeitem, oio.code \n"
+                query = "select ti.manufactureroftradeitem, oio.code, ti.gtin \n"
                         + "from referencedata.trade_items ti, \n"
                         + "(select oi.value, o.code, MAX(o.versionnumber) \n"
                         + "from referencedata.orderable_identifiers oi \n"
@@ -71,7 +71,8 @@ import org.openlmis.referencedata.dto.TradeItemCsvModel;
                         columns = {
                                 @ColumnResult(name = "code", type = String.class),
                                 @ColumnResult(name = "manufacturerOfTradeItem",
-                                        type = String.class)
+                                        type = String.class),
+                                @ColumnResult(name = "gtin", type = String.class)
                         }
                 )
         )

--- a/src/main/java/org/openlmis/referencedata/dto/TradeItemCsvModel.java
+++ b/src/main/java/org/openlmis/referencedata/dto/TradeItemCsvModel.java
@@ -32,11 +32,17 @@ public class TradeItemCsvModel {
 
   private static final String PRODUCT_CODE = "productCode";
   private static final String MANUFACTURER_OF_TRADE_ITEM = "manufacturerOfTradeItem";
+  private static final String GTIN = "gtin";
 
+  // Field order must match the @ConstructorResult column order in
+  // TradeItem.findAllTradeItemCsvModels - the CSV export projection maps by @AllArgsConstructor.
   @ImportField(name = PRODUCT_CODE, type = "code", mandatory = true)
   private String code;
 
   @ImportField(name = MANUFACTURER_OF_TRADE_ITEM)
   private String manufacturerOfTradeItem;
+
+  @ImportField(name = GTIN)
+  private String gtin;
 
 }

--- a/src/main/java/org/openlmis/referencedata/service/export/TradeItemImportPersister.java
+++ b/src/main/java/org/openlmis/referencedata/service/export/TradeItemImportPersister.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import org.openlmis.referencedata.domain.Code;
+import org.openlmis.referencedata.domain.Gtin;
 import org.openlmis.referencedata.domain.Orderable;
 import org.openlmis.referencedata.domain.TradeItem;
 import org.openlmis.referencedata.dto.ImportResponseDto;
@@ -52,6 +53,8 @@ public class TradeItemImportPersister
     implements DataImportPersister<Orderable, TradeItemCsvModel, OrderableDto> {
 
   public static final String TRADE_ITEM_FILE_NAME = "tradeItem.csv";
+
+  private static final String TRADE_ITEM_IDENTIFIER_KEY = "tradeItem";
 
   @Autowired private FileHelper fileHelper;
   @Autowired private TradeItemRepository tradeItemRepository;
@@ -143,7 +146,7 @@ public class TradeItemImportPersister
 
       UUID tradeItemId = tradeItem.getId();
       Map<String, String> identifiers = new HashMap<>();
-      identifiers.put("tradeItem", tradeItemId.toString());
+      identifiers.put(TRADE_ITEM_IDENTIFIER_KEY, tradeItemId.toString());
       orderable.setIdentifiers(identifiers);
 
       orderablePersistList.add(orderable);
@@ -168,12 +171,10 @@ public class TradeItemImportPersister
       TradeItem tradeItem;
       Map<String, String> identifiers = orderable.getIdentifiers();
 
-      if (identifiers == null || !identifiers.containsKey("tradeItem")) {
-        TradeItemDto tradeItemDto = new TradeItemDto();
-        tradeItemDto.setManufacturerOfTradeItem(dto.getManufacturerOfTradeItem());
-        tradeItem = TradeItem.newInstance(tradeItemDto);
+      if (identifiers == null || !identifiers.containsKey(TRADE_ITEM_IDENTIFIER_KEY)) {
+        tradeItem = TradeItem.newInstance(new TradeItemDto());
       } else {
-        String tradeItemIdentifier = identifiers.get("tradeItem");
+        String tradeItemIdentifier = identifiers.get(TRADE_ITEM_IDENTIFIER_KEY);
         tradeItem =
             tradeItemRepository
                 .findById(UUID.fromString(tradeItemIdentifier))
@@ -181,12 +182,20 @@ public class TradeItemImportPersister
                     () ->
                         new NotFoundException(
                             "Could not find trade item with id: " + tradeItemIdentifier));
-        tradeItem.setManufacturerOfTradeItem(dto.getManufacturerOfTradeItem());
       }
+
+      applyCsvFields(tradeItem, dto);
 
       tradeItemPersistMap.put(orderable, tradeItem);
     }
 
     return tradeItemPersistMap;
+  }
+
+  private void applyCsvFields(TradeItem tradeItem, TradeItemCsvModel dto) {
+    tradeItem.setManufacturerOfTradeItem(dto.getManufacturerOfTradeItem());
+    if (dto.getGtin() != null) {
+      tradeItem.setGtin(new Gtin(dto.getGtin()));
+    }
   }
 }

--- a/src/main/resources/data-export/mapping/csv/tradeItem_mapping.csv
+++ b/src/main/resources/data-export/mapping/csv/tradeItem_mapping.csv
@@ -1,3 +1,4 @@
 from,to,type,entityName,defaultValue
 productCode,productCode,DIRECT,,
 manufacturerOfTradeItem,manufacturerOfTradeItem,DIRECT,,
+gtin,gtin,DIRECT,,

--- a/src/test/java/org/openlmis/referencedata/service/TradeItemServiceTest.java
+++ b/src/test/java/org/openlmis/referencedata/service/TradeItemServiceTest.java
@@ -61,8 +61,8 @@ public class TradeItemServiceTest {
 
   @Test
   public void shouldReturnAllTradeItemCsvModels() {
-    TradeItemCsvModel model1 = new TradeItemCsvModel("product-code-1", "manufacturer-1");
-    TradeItemCsvModel model2 = new TradeItemCsvModel("product-code-2", "manufacturer-2");
+    TradeItemCsvModel model1 = new TradeItemCsvModel("product-code-1", "manufacturer-1", null);
+    TradeItemCsvModel model2 = new TradeItemCsvModel("product-code-2", "manufacturer-2", null);
     List<TradeItemCsvModel> modelList = Lists.newArrayList(model1, model2);
     final int modelListSize = modelList.size();
     when(tradeItemRepository.findAllTradeItemCsvModels()).thenReturn(modelList);

--- a/src/test/java/org/openlmis/referencedata/service/export/TradeItemImportPersisterTest.java
+++ b/src/test/java/org/openlmis/referencedata/service/export/TradeItemImportPersisterTest.java
@@ -52,6 +52,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 @RunWith(MockitoJUnitRunner.class)
 public class TradeItemImportPersisterTest {
 
+  private static final String GTIN_8 = "96385074";
+  private static final String PADDED_GTIN_8 = "00000096385074";
+
   private InputStream dataStream;
   private TradeItemCsvModel csvModel;
   private Orderable orderable;
@@ -72,7 +75,7 @@ public class TradeItemImportPersisterTest {
 
     // Initialize objects
     identifier = UUID.randomUUID().toString();
-    csvModel = new TradeItemCsvModel("code", "manufacturer");
+    csvModel = new TradeItemCsvModel("code", "manufacturer", null);
     tradeItem = new TradeItemDataBuilder().build();
     orderable = new OrderableDataBuilder().withIdentifier("tradeItem", identifier).build();
 
@@ -102,6 +105,19 @@ public class TradeItemImportPersisterTest {
     verify(fileHelper).readCsv(TradeItemCsvModel.class, dataStream);
     verify(tradeItemRepository).saveAll(any());
     verify(orderableRepository).saveAll(any());
+  }
+
+  @Test
+  public void shouldNormalizeGtinWhenPresent() throws InterruptedException {
+    // Given a short, check-digit-valid GTIN-8
+    csvModel = new TradeItemCsvModel("code", "manufacturer", GTIN_8);
+    setupMocksForSuccess();
+
+    // When
+    tradeItemImportPersister.processAndPersist(dataStream, mock(Profiler.class));
+
+    // Then it is stored zero-padded to the 14-digit form
+    assertEquals(PADDED_GTIN_8, tradeItem.getGtin().getGtin());
   }
 
   private void setupMocksForSuccess() {


### PR DESCRIPTION
## What this does

Adds a `gtin` column to the trade item CSV import. On write the value goes through the `Gtin` value object from OLMIS-8287, so it is normalized to 14 digits and validated (length and GS1 check digit) the same way as any other GTIN.

The import model is shared with the export, so the trade item CSV export now carries a `gtin` column as well. Existing export consumers will see the new column, so it is worth calling out in the release notes.

## Why

Barcode scanning (OLMIS-8236) is not useful until trade items actually have GTINs registered, and typing hundreds of them by hand is not realistic. This is the bulk-load path for that (T8 in the barcode-scanning HLD).

## Notes

- The column is optional, so existing two-column files import exactly as before.
- A blank gtin cell leaves the trade item's existing GTIN alone.
- Validation is fail-fast: a malformed value rejects the file with the existing GTIN messages, and a duplicate is caught by the existing unique-constraint handler. Per-row error reporting was left out on purpose, since the persister has no per-row mechanism today and the ticket is scoped small.

## Testing

- Unit test for gtin normalization on import.
- Integration tests for the create and update paths (a short GTIN is stored zero-padded, a blank cell registers no GTIN) and for the gtin showing up in the export projection.
- The existing two-column import test still passes.
- `./gradlew check` and the integration tests pass.

## Ticket

https://openlmis.atlassian.net/browse/OLMIS-8289
